### PR TITLE
#166

### DIFF
--- a/ita_root/common_libs/ansible_driver/classes/ansibletowerlibs/ExecuteDirector.py
+++ b/ita_root/common_libs/ansible_driver/classes/ansibletowerlibs/ExecuteDirector.py
@@ -1922,6 +1922,7 @@ class ExecuteDirector():
                 stdout = JobDetail['stdout']
                 JobId = JobData['id']
                 jobName = JobData['name']
+                jobNo = JobData['name'][-10:]
                 if self.workflowJobAry[wfJobId]['is_sliced_job'] is True:
                     # ジョブスライス数
                     job_slice_count = JobData['job_slice_count']
@@ -1942,7 +1943,9 @@ class ExecuteDirector():
                 result_stdout += stdout
 
                 # オリジナルログファイル
-                jobFileFullPath = "%s/%s_%s.txt.org" % (outDirectoryPath, JobData['name'], job_slice_number_str)
+                # jobFileFullPath = "%s/%s_%s.txt.org" % (outDirectoryPath, JobData['name'], job_slice_number_str)
+                # ファイル名を短くする。
+                jobFileFullPath = "%s/exec_%s_%s.log.org" % (outDirectoryPath, jobNo, job_slice_number_str)
                 try:
                     pathlib.Path(jobFileFullPath).write_text(result_stdout)
 
@@ -1960,7 +1963,9 @@ class ExecuteDirector():
 
                 # jobログを加工
                 result_stdout = self.LogReplacement(result_stdout)
-                jobFileFullPath = '%s/%s_%s.txt' % (outDirectoryPath, JobData['name'], job_slice_number_str)
+                # jobFileFullPath = '%s/%s_%s.txt' % (outDirectoryPath, JobData['name'], job_slice_number_str)
+                # ファイル名を短くする。
+                jobFileFullPath = '%s/exec_%s_%s.log' % (outDirectoryPath, jobNo, job_slice_number_str)
                 try:
                     pathlib.Path(jobFileFullPath).write_text(result_stdout)
 


### PR DESCRIPTION
分割されたログファイル名が長すぎるので、短くする。
修正前
　ジョブテンプレート名_通番10桁.txt
　ita_legacy_role_executions_jobtpl_0b72969f-5841-419c-acef-d6232244835c_0000000001_0000000000.txt
修正後
　exec_ジョブテンプレート通番_通番10桁.log
　exec_0000000001_0000000000.log
