### PR TITLE
#70, #71

### DIFF
--- a/ita_root/common_libs/ansible_driver/classes/SubValueAutoReg.py
+++ b/ita_root/common_libs/ansible_driver/classes/SubValueAutoReg.py
@@ -130,7 +130,7 @@ class SubValueAutoReg():
         frame = inspect.currentframe().f_back
         g.applogger.debug(os.path.basename(__file__) + str(frame.f_lineno) + traceMsg)
 
-        ret = self.read_val_assign(self.in_driver_name, self.ws_db)
+        ret = self.read_val_assign(self.in_driver_name, self.ws_db, movement_id)
 
         if ret[0] == 0:
             error_flag = 1


### PR DESCRIPTION
代入値自動登録に複数Movementの変数を紐づけ場合の不備