### PR TITLE
イベントフロー画面向けのAPI定義を追加

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - DB_ADMIN_PASSWORD=${DB_ADMIN_PASSWORD}
       - PLATFORM_API_HOST=platform-api
       - PLATFORM_API_PORT=8000
+      - MONGO_HOST=${MONGO_HOST}
+      - MONGO_PORT=${MONGO_PORT}
   ita-api-admin:
     user: 1000:1000
     build:

--- a/ita_root/ita_api_organization/Dockerfile
+++ b/ita_root/ita_api_organization/Dockerfile
@@ -58,6 +58,7 @@ RUN dnf install -y \
 &&  pip3.9 install --upgrade dictdiffer \
 &&  pip3.9 install --upgrade python-hcl2 \
 &&  pip3.9 install --upgrade pyrsistent \
+&&  pip3.9 install --upgrade pymongo \
 &&  groupadd $GROUPNAME \
 &&  useradd -m -s /bin/bash -g $GROUPNAME $USERNAME \
 &&  setcap 'cap_net_bind_service=+ep' /usr/sbin/httpd \

--- a/ita_root/ita_api_organization/controllers/event_relay_controller.py
+++ b/ita_root/ita_api_organization/controllers/event_relay_controller.py
@@ -16,6 +16,7 @@ import sys
 
 sys.path.append('../../')
 from common_libs.common import *  # noqa: F403
+from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 from common_libs.loadtable.load_table import loadTable
 from common_libs.api import api_filter
 from libs.organization_common import check_menu_info, check_auth_menu, check_sheet_type
@@ -68,5 +69,39 @@ def post_check_monitoring_software(organization_id, workspace_id, body=None):  #
     """
 
     result_data = {}
+
+    return result_data,
+
+
+@api_filter
+def post_event_flow(organization_id, workspace_id, body=None):  # noqa: E501
+    """post_event_history
+
+    検索条件を指定し、イベントフロー画面に描画する情報を取得する # noqa: E501
+
+    :param organization_id: OrganizationID
+    :type organization_id: str
+    :param workspace_id: WorkspaceID
+    :type workspace_id: str
+    :param body:
+    :type body: dict | bytes
+
+    :rtype: InlineResponse2006
+    """
+
+    wsDb = DBConnectWs(workspace_id=workspace_id)
+    wsMongo = MONGOConnectWs()
+
+    parameter = {}
+    if connexion.request.is_json:
+        parameter = dict(connexion.request.get_json())
+
+    result_data = {}
+
+    result_data["event_history"] = event_relay.collect_event_history(wsMongo, parameter)
+    result_data["action_log"] = event_relay.collect_action_log(wsDb, parameter)
+    result_data["filter"] = event_relay.collect_filter(wsDb)
+    result_data["action"] = event_relay.collect_action(wsDb)
+    result_data["rule"] = event_relay.collect_rule(wsDb)
 
     return result_data,

--- a/ita_root/ita_api_organization/libs/event_relay.py
+++ b/ita_root/ita_api_organization/libs/event_relay.py
@@ -16,8 +16,10 @@ import os
 from flask import g
 
 from common_libs.common import *  # noqa: F403
+from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 from common_libs.loadtable import *
-
+from datetime import datetime
+from pymongo import ASCENDING
 
 def rest_filter(objdbca, menu, filter_parameter):
     """
@@ -47,3 +49,214 @@ def rest_filter(objdbca, menu, filter_parameter):
 
     return result
 
+
+def collect_event_history(wsMongo: MONGOConnectWs, parameter: dict):
+    """
+    検索条件を指定し、イベント履歴を取得する
+    ARGS:
+        wsMongo:DB接続クラス  MONGOConnectWs()
+        parameter:bodyの中身
+    RETRUN:
+        data
+    """
+
+    # イベント履歴のコレクション名
+    COLLECTION_NAME = "labeled_event_collection"
+
+    # MongoDBから取得するデータのソート条件
+    SORT_KEY = [
+        ("labels._exastro_fetched_time", ASCENDING),
+        ("labels._exastro_end_time", ASCENDING),
+        ("_id", ASCENDING)
+    ]
+
+    def create_filter():
+        """
+        イベント履歴の検索に使用する条件を取得する
+        RETRUN:
+            filter
+        """
+
+        # APIのリクエストパラメータとmongoDBのイベント履歴の項目の対応表。
+        PARAM_MAP = {
+            "start_time": "labels._exastro_end_time",
+            "end_time": "labels._exastro_fetched_time",
+            "evaluted": "labels._exastro_evaluated",
+            "undetected": "labels._exastro_undetected",
+            "timeouted": "labels._exastro_time_out"
+        }
+
+        # UNIX時間への変換処理を行うパラメータ。
+        TIME_PARAM = ["start_time", "end_time"]
+
+        # boolから0,1への変換処理を行うパラメータ。
+        BOOL_PARAM = ["evaluted", "undetected", "timeouted"]
+
+        filter = {}
+        for key, value in parameter.items():
+            # 想定していないパラメータを渡された場合は次のパラメータにスキップする。
+            param_key = PARAM_MAP.get(key)
+            if param_key is None:
+                continue
+
+            fix_value = None
+            # MongoDBのデータに合わせるため、時刻項目の場合UNIX時間に変換する。
+            if key in TIME_PARAM:
+                dt = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S%z')
+                fix_value = str(int(dt.timestamp()))
+            # MongoDBのデータに合わせるため、Bool値の場合は一旦intに変換し、その後文字に変換する。
+            elif key in BOOL_PARAM:
+                fix_value = str(int(value))
+            # 初期化漏れを防ぐため定義。扱うパラメータを考慮すると通ることはない。
+            else:
+                fix_value = value
+
+            # UNIX時間は範囲を条件とするため値の設定方法を変える
+            if key == "start_time":
+                filter[param_key] = {"$gte": fix_value}
+            elif key == "end_time":
+                filter[param_key] = {"$lte": fix_value}
+            else:
+                filter[param_key] = fix_value
+
+        return filter
+
+    event_history = (wsMongo.collection(COLLECTION_NAME)
+                     .find(create_filter())
+                     .sort(SORT_KEY))
+
+    # MongoDBから取得した値をそのまま返却するとエラーになるため原因となる項目（_id）を変換する
+    result = []
+    for item in event_history:
+        # TODO:MongoDBのIDは単純にstringに変換で良いか（ObjectId()の部分が無くなる）
+        item["_id"] = str(item["_id"])
+        result.append(item)
+
+    return result
+
+
+def collect_action_log(wsDb: DBConnectWs, parameter: dict):
+    """
+    検索条件を指定し、アクション履歴を取得する
+    ARGS:
+        wsDb:DB接続クラス  DBConnectWs()
+        parameter:bodyの中身
+    RETRUN:
+        data
+    """
+
+    # アクション履歴テーブルの物理名
+    TABLE_NAME = "T_EVRL_ACTION_LOG"
+
+    # 取得するアクション履歴のソート条件
+    SORT_KEY = "ORDER BY TIME_REGISTER, ACTION_LOG_ID"
+
+    def create_where():
+        """
+        アクション履歴の検索に使用する条件を取得する
+        RETRUN:
+            where: where句の文字列
+            bind_value: 検索で指定する値
+        """
+
+        TARGET_PARAM = ["start_time", "end_time"]
+
+        # 後にORDER BY句の文字列を結合することを考慮して予め末尾にスペースを仕込んでおく。
+        where = "WHERE DISUSE_FLAG=0 "
+        bind_value = []
+        for key, value in parameter.items():
+            # 想定していないパラメータを渡された場合は次のパラメータにスキップする。
+            if key not in TARGET_PARAM:
+                continue
+
+            # TODO:検索条件は登録時間で良いか要確認（最終更新時間では無いことを確定させたい）
+            # 片落ちで指定されることを想定してBetweenは使わない。
+            if key == "start_time":
+                where += "AND TIME_REGISTER >= %s "
+            elif key == "end_time":
+                where += "AND TIME_REGISTER <= %s "
+
+            bind_value.append(value)
+
+        return where, bind_value
+
+    where, bind_value = create_where()
+    action_log = wsDb.table_select(
+        TABLE_NAME,
+        where + SORT_KEY,
+        bind_value
+    )
+
+    return action_log
+
+
+def collect_filter(wsDb: DBConnectWs):
+    """
+    フィルター管理を取得する
+    ARGS:
+        wsDb:DB接続クラス  DBConnectWs()
+    RETRUN:
+        data
+    """
+
+    # フィルター管理テーブルの物理名
+    TABLE_NAME = "T_EVRL_FILTER"
+
+    # 取得するフィルター管理のソート条件
+    # TODO:テーブル定義からソート列が確認できなかったため仮で作成
+    SORT_KEY = "ORDER BY FILTER_NAME, FILTER_ID"
+
+    where = "WHERE DISUSE_FLAG=0 "
+    filter = wsDb.table_select(
+        TABLE_NAME,
+        where + SORT_KEY
+    )
+
+    return filter
+
+
+def collect_action(wsDb: DBConnectWs):
+    """
+    アクション定義を取得する
+    ARGS:
+        wsDb:DB接続クラス  DBConnectWs()
+    RETRUN:
+        data
+    """
+
+    # アクション定義テーブルの物理名
+    TABLE_NAME = "T_EVRL_ACTION"
+
+    # 取得するアクション定義のソート条件
+    SORT_KEY = "ORDER BY ACTION_NAME, ACTION_ID"
+
+    where = "WHERE DISUSE_FLAG=0 "
+    action = wsDb.table_select(
+        TABLE_NAME,
+        where + SORT_KEY
+    )
+
+    return action
+
+
+def collect_rule(wsDb: DBConnectWs):
+    """
+    ルール定義を取得する
+    ARGS:
+        wsDb:DB接続クラス  DBConnectWs()
+    RETRUN:
+        data
+    """
+
+    # ルール管理テーブルの物理名
+    TABLE_NAME = "T_EVRL_RULE"
+
+    # 取得するルール管理のソート条件
+    SORT_KEY = "ORDER BY RULE_NAME, RULE_ID"
+
+    where = "WHERE DISUSE_FLAG=0 "
+    rule = wsDb.table_select(
+        TABLE_NAME,
+        where + SORT_KEY
+    )
+    return rule

--- a/ita_root/ita_api_organization/openapi.yaml
+++ b/ita_root/ita_api_organization/openapi.yaml
@@ -5780,6 +5780,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/ERROR_TEMPLATE'
 
+  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/:
+    post:
+      tags:
+        - Event Relay
+      description: 検索条件を指定し、イベントフロー画面に描画する情報を取得する
+      operationId: postEventFlow
+      x-openapi-router-controller: controllers.event_relay_controller
+      parameters:
+        - name: organization_id
+          in: path
+          description: OrganizationID
+          required: true
+          schema:
+            type: string
+        - name: workspace_id
+          in: path
+          description: WorkspaceID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: 検索条件を指定
+              properties:
+                start_time:
+                  type: string
+                  format: date-time
+                  example: "2017-07-21T17:32:28Z"
+                end_time:
+                  type: string
+                  format: date-time
+                  example: "2017-07-21T17:32:28Z"
+                evaluted:
+                  type: boolean
+                  example: "true"
+                undetected:
+                  type: boolean
+                  example: "false"
+                timeouted:
+                  type: boolean
+                  example: "false"
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+                    example: 000-00000
+                  data:
+                    type: object
+                    example: {"action":[{}], "action_log":[{}],"event_history":[{}], "filter":[{}], "rule":[{}] }
+                  message:
+                    type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
 components:
   schemas:
     TABLE:

--- a/ita_root/ita_api_organization/swagger/swagger.yaml
+++ b/ita_root/ita_api_organization/swagger/swagger.yaml
@@ -5097,6 +5097,72 @@ paths:
               schema:
                 $ref: '#/components/schemas/ERROR_TEMPLATE'
       x-openapi-router-controller: controllers.event_relay_controller
+  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/:
+    post:
+      tags:
+      - Event Relay
+      description: 検索条件を指定し、イベントフロー画面に描画する情報を取得する
+      operationId: post_event_flow
+      parameters:
+      - name: organization_id
+        in: path
+        description: OrganizationID
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: workspace_id
+        in: path
+        description: WorkspaceID
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: 検索条件を指定
+              properties:
+                start_time:
+                  type: string
+                  format: date-time
+                  example: "2017-07-21T17:32:28Z"
+                end_time:
+                  type: string
+                  format: date-time
+                  example: "2017-07-21T17:32:28Z"
+                evaluted:
+                  type: boolean
+                  example: "true"
+                undetected:
+                  type: boolean
+                  example: "false"
+                timeouted:
+                  type: boolean
+                  example: "false"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inline_response_200_22'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+      x-openapi-router-controller: controllers.event_relay_controller
 components:
   schemas:
     TABLE:
@@ -6534,6 +6600,20 @@ components:
           file_name: "{compare_name}_YYYY/MMDDhhmmss.xlsx"
           file_data: Compare result base64 string
         message: message
+    inline_response_200_22:
+      type: object
+      properties:
+        result:
+          type: string
+          example: 000-00000
+        data:
+          $ref: '#/components/schemas/inline_response_200_22_data'
+        message:
+          type: string
+      example:
+        result: 000-00000
+        data: {"action":[{}], "action_log":[{}],"event_history":[{}], "filter":[{}], "rule":[{}] }
+        message: message
     execute_file_body:
       properties:
         compare:
@@ -7239,6 +7319,43 @@ components:
       example:
         file_name: "{compare_name}_YYYY/MMDDhhmmss.xlsx"
         file_data: Compare result base64 string
+    inline_response_200_22_data:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            action:
+              type: array
+              items:
+                type: object
+                example:
+                - アクション定義のカラム名
+            action_log:
+              type: array
+              items:
+                type: object
+                example:
+                - アクション履歴のカラム名
+            event_history:
+              type: array
+              items:
+                type: object
+                example:
+                - MongoDBから取得したイベント履歴のドキュメント
+            filter:
+              type: array
+              items:
+                type: object
+                example:
+                - フィルター管理のカラム名
+            rule:
+              type: array
+              items:
+                type: object
+                example:
+                - ルール管理のカラム名
+      example:
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid


### PR DESCRIPTION
# 概要
以下の対応を実施いたしました。
- イベントフロー画面向けのデータ取得APIを追加

## 詳細
- .devcontainer/docker-compose.yml
  - ita-api-organizationに以下のenvironmentを追加
     - MONGO_HOST=${MONGO_HOST}
     - MONGO_PORT=${MONGO_PORT}
- ita_root/ita_api_organization/Dockerfile
  - common_buildのRUNに以下を追加
   - &&  pip3.9 install --upgrade pymongo \
- ita_root/ita_api_organization/controllers/event_relay_controller.py
  - 追加したAPI定義に対応する処理を追加
  - 上に伴い、必要なモジュールのimportを追加
- ita_root/ita_api_organization/libs/event_relay.py
  - イベントフロー画面向けのAPIで使用するビジネスロジックを追加
- ita_root/ita_api_organization/openapi.yaml
  - イベントフロー画面向けのAPI定義を一つ追加
- ita_root/ita_api_organization/swagger/swagger.yaml
  - イベントフロー画面向けのAPI定義を一つ追加