### PR TITLE
イベントフロー画面向けAPIの分割対応

### DIFF
--- a/ita_root/ita_api_organization/controllers/event_relay_controller.py
+++ b/ita_root/ita_api_organization/controllers/event_relay_controller.py
@@ -74,8 +74,8 @@ def post_check_monitoring_software(organization_id, workspace_id, body=None):  #
 
 
 @api_filter
-def post_event_flow(organization_id, workspace_id, body=None):  # noqa: E501
-    """post_event_history
+def post_event_flow_history(organization_id, workspace_id, body=None):  # noqa: E501
+    """post_event_flow_history
 
     検索条件を指定し、イベントフロー画面に描画する情報を取得する # noqa: E501
 
@@ -86,7 +86,7 @@ def post_event_flow(organization_id, workspace_id, body=None):  # noqa: E501
     :param body:
     :type body: dict | bytes
 
-    :rtype: InlineResponse2006
+    :rtype: InlineResponse20022
     """
 
     wsDb = DBConnectWs(workspace_id=workspace_id)
@@ -96,10 +96,32 @@ def post_event_flow(organization_id, workspace_id, body=None):  # noqa: E501
     if connexion.request.is_json:
         parameter = dict(connexion.request.get_json())
 
+    event_history = event_relay.collect_event_history(wsMongo, parameter)
+    action_history = event_relay.collect_action_log(wsDb, parameter)
+
+    history_data = event_relay.create_history_list(event_history, action_history)
+
+    return history_data,
+
+
+@api_filter
+def get_event_flow_definition(organization_id, workspace_id):  # noqa: E501
+    """get_event_flow_definition
+
+    イベントフローで扱う定義情報（ラベル、アクション、ルール）を取得する
+
+    :param organization_id: OrganizationID
+    :type organization_id: str
+    :param workspace_id: WorkspaceID
+    :type workspace_id: str
+
+    :rtype: InlineResponse20023
+    """
+
+    wsDb = DBConnectWs(workspace_id=workspace_id)
+
     result_data = {}
 
-    result_data["event_history"] = event_relay.collect_event_history(wsMongo, parameter)
-    result_data["action_log"] = event_relay.collect_action_log(wsDb, parameter)
     result_data["filter"] = event_relay.collect_filter(wsDb)
     result_data["action"] = event_relay.collect_action(wsDb)
     result_data["rule"] = event_relay.collect_rule(wsDb)

--- a/ita_root/ita_api_organization/libs/event_relay.py
+++ b/ita_root/ita_api_organization/libs/event_relay.py
@@ -260,3 +260,50 @@ def collect_rule(wsDb: DBConnectWs):
         where + SORT_KEY
     )
     return rule
+
+
+def create_history_list(event_history: list, action_log: list) :
+    """
+    イベント履歴とアクション履歴をまとめて日時の昇順でソートしたリストを作成する
+    ARGS:
+        event_history:イベント履歴のリスト
+        action_log:アクション履歴のリスト
+    RETRUN:
+        history_list
+    """
+
+    history_list = []
+
+    for event in event_history:
+        append_data = {}
+        append_data["id"] = event["_id"]
+        append_data["type"] = "event"
+
+        ts = int(event["labels"]["_exastro_fetched_time"])
+        dt = datetime.fromtimestamp(ts)
+        append_data["datetime"] = dt.strftime("%Y-%m-%d %H:%M:%S")
+
+        append_data["item"] = event
+
+        history_list.append(append_data)
+
+    for action in action_log:
+        append_data = {}
+        append_data["id"] = action["ACTION_LOG_ID"]
+        append_data["type"] = "action"
+
+        tr = action["TIME_REGISTER"]
+        append_data["datetime"] = tr.strftime("%Y-%m-%d %H:%M:%S")
+
+        append_data["item"] = action
+
+        history_list.append(append_data)
+
+    # 毎回同じ順序で取得できるようにidをソートキーに加える
+    # （UUIDなので追加されると順番が崩れ可能性はあるが、過去データを参照する場合は問題ない認識）
+    # またイベントの結果アクションが発生するという流れを考慮しイベントが先に来るようにtypeをソートキーに指定
+    history_list.sort(key=lambda x: x["id"], reverse=False)
+    history_list.sort(key=lambda x: x["type"], reverse=True)
+    history_list.sort(key=lambda x: x["datetime"], reverse=False)
+
+    return history_list

--- a/ita_root/ita_api_organization/openapi.yaml
+++ b/ita_root/ita_api_organization/openapi.yaml
@@ -5780,11 +5780,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ERROR_TEMPLATE'
 
-  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/:
+  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/history/:
     post:
       tags:
         - Event Relay
-      description: 検索条件を指定し、イベントフロー画面に描画する情報を取得する
+      description: 検索条件を指定し、イベントフローで扱う履歴情報（イベント履歴、アクション履歴）を取得する
       operationId: postEventFlow
       x-openapi-router-controller: controllers.event_relay_controller
       parameters:
@@ -5835,8 +5835,57 @@ paths:
                     type: string
                     example: 000-00000
                   data:
+                    type: array
+                    example: []
+                  message:
+                    type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+
+  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/definition/:
+    get:
+      tags:
+        - Event Relay
+      description: イベントフローで扱う定義情報（ラベル、アクション、ルール）を取得する
+      operationId: getEventFlowDefinition
+      x-openapi-router-controller: controllers.event_relay_controller
+      parameters:
+        - name: organization_id
+          in: path
+          description: OrganizationID
+          required: true
+          schema:
+            type: string
+        - name: workspace_id
+          in: path
+          description: WorkspaceID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+                    example: 000-00000
+                  data:
                     type: object
-                    example: {"action":[{}], "action_log":[{}],"event_history":[{}], "filter":[{}], "rule":[{}] }
+                    example: {"action":[{}], "filter":[{}], "rule":[{}] }
                   message:
                     type: string
         '401':

--- a/ita_root/ita_api_organization/swagger/swagger.yaml
+++ b/ita_root/ita_api_organization/swagger/swagger.yaml
@@ -5097,12 +5097,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ERROR_TEMPLATE'
       x-openapi-router-controller: controllers.event_relay_controller
-  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/:
+  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/history/:
     post:
       tags:
       - Event Relay
-      description: 検索条件を指定し、イベントフロー画面に描画する情報を取得する
-      operationId: post_event_flow
+      description: 検索条件を指定し、イベントフローで扱う履歴情報（イベント履歴、アクション履歴）を取得する
+      operationId: post_event_flow_history
       parameters:
       - name: organization_id
         in: path
@@ -5150,6 +5150,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/inline_response_200_22'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+      x-openapi-router-controller: controllers.event_relay_controller
+  /api/{organization_id}/workspaces/{workspace_id}/ita/event_relay/event_flow/definition/:
+    get:
+      tags:
+      - Event Relay
+      description: イベントフローで扱う定義情報（ラベル、アクション、ルール）を取得する
+      operationId: get_event_flow_definition
+      parameters:
+      - name: organization_id
+        in: path
+        description: OrganizationID
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: workspace_id
+        in: path
+        description: WorkspaceID
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inline_response_200_23'
         "401":
           description: Unauthorized
           content:
@@ -6612,7 +6655,21 @@ components:
           type: string
       example:
         result: 000-00000
-        data: {"action":[{}], "action_log":[{}],"event_history":[{}], "filter":[{}], "rule":[{}] }
+        data: []
+        message: message
+    inline_response_200_23:
+      type: object
+      properties:
+        result:
+          type: string
+          example: 000-00000
+        data:
+          $ref: '#/components/schemas/inline_response_200_23_data'
+        message:
+          type: string
+      example:
+        result: 000-00000
+        data: {"action":[{}], "filter":[{}], "rule":[{}] }
         message: message
     execute_file_body:
       properties:
@@ -7323,6 +7380,14 @@ components:
       type: object
       properties:
         data:
+          type: array
+          items:
+            example: イベント履歴とアクション履歴をまとめて日時の昇順でソートした一覧
+      example:
+    inline_response_200_23_data:
+      type: object
+      properties:
+        data:
           type: object
           properties:
             action:
@@ -7331,18 +7396,6 @@ components:
                 type: object
                 example:
                 - アクション定義のカラム名
-            action_log:
-              type: array
-              items:
-                type: object
-                example:
-                - アクション履歴のカラム名
-            event_history:
-              type: array
-              items:
-                type: object
-                example:
-                - MongoDBから取得したイベント履歴のドキュメント
             filter:
               type: array
               items:


### PR DESCRIPTION
# 概要
イベントフロー画面向けAPIの分割対応を行いました。

## 詳細
- 既存APIをイベント履歴とアクション履歴を取得するAPIに修正
  - イベント履歴とアクション履歴は個別に返していたので、一つのリストにまとめるよう実装を変更
- ラベル、アクション、ルールを取得するAPIを追加