### PR TITLE
OpenAPIのドキュメント不備を解消

### DIFF
--- a/ita_root/ita_api_organization/openapi.yaml
+++ b/ita_root/ita_api_organization/openapi.yaml
@@ -5905,6 +5905,20 @@ paths:
                     example: 000-00000
                   data:
                     type: array
+                    items:
+                      type: object
+                      properties:
+                        datetime:
+                          type: string
+                          example: "2023-09-12 15:41:29"
+                        id:
+                          type: string
+                        item:
+                          type: object
+                          description: "イベント履歴かアクション履歴から取得した内容"
+                        type:
+                          type: string
+                          description: "取得元を判断するための文字列。イベント履歴：event, アクション履歴：action"
                     example: []
                   message:
                     type: string

--- a/ita_root/ita_api_organization/swagger/swagger.yaml
+++ b/ita_root/ita_api_organization/swagger/swagger.yaml
@@ -6793,68 +6793,6 @@ components:
         rest_key_name:
           $ref: '#/components/schemas/FILTER_REQUEST_PARAMETERS'
       description: 検索条件を設定
-    event_flow_history_body:
-      properties:
-        start_time:
-          type: string
-          format: date-time
-          example: 2017-07-21T17:32:28Z
-        end_time:
-          type: string
-          format: date-time
-          example: 2017-07-21T17:32:28Z
-        evaluted:
-          type: boolean
-          example: true
-        undetected:
-          type: boolean
-          example: false
-        timeouted:
-          type: boolean
-          example: false
-      description: 検索条件を指定
-    inline_response_200_22:
-      type: object
-      properties:
-        result:
-          type: string
-          example: 000-00000
-        data:
-          type: array
-          example: []
-        message:
-          type: string
-      example:
-        result: 000-00000
-        data: []
-        message: message
-    inline_response_200_23:
-      type: object
-      properties:
-        result:
-          type: string
-          example: 000-00000
-        data:
-          type: object
-          example:
-            action:
-            - {}
-            filter:
-            - {}
-            rule:
-            - {}
-        message:
-          type: string
-      example:
-        result: 000-00000
-        data:
-          action:
-          - {}
-          filter:
-          - {}
-          rule:
-          - {}
-        message: message
     FILTER_REQUEST_PARAMETERS_RANGE:
       type: object
       properties:


### PR DESCRIPTION
# 概要
[1596](https://github.com/exastro-suite/exastro-it-automation/pull/1596)でOpenAPIのドキュメントに定義を追加した際に不備があったため、その修正を実施。

## 詳細
- openapi.yaml
  - arrayを定義する際のitemsが漏れていたので追加
- swagger.yaml
  - 未使用の定義を削除
    - event_flow_history_body
  - 重複した定義を削除
    - inline_response_200_22
    - inline_response_200_23