### PR TITLE
openapi.yamlの修正および自動生成ファイルに対する作業不備対応

### DIFF
--- a/ita_root/ita_api_organization/controllers/event_relay_controller.py
+++ b/ita_root/ita_api_organization/controllers/event_relay_controller.py
@@ -22,6 +22,32 @@ from common_libs.api import api_filter
 from libs.organization_common import check_menu_info, check_auth_menu, check_sheet_type
 from libs import event_relay
 
+
+@api_filter
+def get_event_flow_definition(organization_id, workspace_id):  # noqa: E501
+    """get_event_flow_definition
+
+    イベントフローで扱う定義情報（ラベル、アクション、ルール）を取得する # noqa: E501
+
+    :param organization_id: OrganizationID
+    :type organization_id: str
+    :param workspace_id: WorkspaceID
+    :type workspace_id: str
+
+    :rtype: InlineResponse20023
+    """
+
+    wsDb = DBConnectWs(workspace_id=workspace_id)
+
+    result_data = {}
+
+    result_data["filter"] = event_relay.collect_filter(wsDb)
+    result_data["action"] = event_relay.collect_action(wsDb)
+    result_data["rule"] = event_relay.collect_rule(wsDb)
+
+    return result_data,
+
+
 @api_filter
 def get_event_relay_filter(organization_id, workspace_id, menu):  # noqa: E501
     """get_event_relay_filter
@@ -52,6 +78,56 @@ def get_event_relay_filter(organization_id, workspace_id, menu):  # noqa: E501
     filter_parameter = {}
     result_data = event_relay.rest_filter(objdbca, menu, filter_parameter)
     return result_data,
+
+
+@api_filter
+def post_check_monitoring_software(organization_id, workspace_id):  # noqa: E501
+    """post_check_monitoring_software
+
+    対象の監視ソフトの連携状態を確認する # noqa: E501
+
+    :param organization_id: OrganizationID
+    :type organization_id: str
+    :param workspace_id: WorkspaceID
+    :type workspace_id: str
+
+    :rtype: InlineResponse2006
+    """
+
+    result_data = {}
+
+    return result_data,
+
+
+@api_filter
+def post_event_flow_history(organization_id, workspace_id, body=None):  # noqa: E501
+    """post_event_flow_history
+
+    検索条件を指定し、イベントフローで扱う履歴情報（イベント履歴、アクション履歴）を取得する # noqa: E501
+
+    :param organization_id: OrganizationID
+    :type organization_id: str
+    :param workspace_id: WorkspaceID
+    :type workspace_id: str
+    :param body:
+    :type body: dict | bytes
+
+    :rtype: InlineResponse20022
+    """
+
+    wsDb = DBConnectWs(workspace_id=workspace_id)
+    wsMongo = MONGOConnectWs()
+
+    parameter = {}
+    if connexion.request.is_json:
+        parameter = dict(connexion.request.get_json())
+
+    event_history = event_relay.collect_event_history(wsMongo, parameter)
+    action_history = event_relay.collect_action_log(wsDb, parameter)
+
+    history_data = event_relay.create_history_list(event_history, action_history)
+
+    return history_data,
 
 
 @api_filter
@@ -91,100 +167,4 @@ def post_event_relay_filter(organization_id, workspace_id, menu, body=None):  # 
         filter_parameter = body
 
     result_data = event_relay.rest_filter(objdbca, menu, filter_parameter)
-    return result_data,
-
-
-@api_filter
-def post_check_monitoring_software(organization_id, workspace_id, body=None):  # noqa: E501
-    """post_check_monitoring_software
-
-    対象の監視ソフトの連携状態を確認する # noqa: E501
-
-    :param organization_id: OrganizationID
-    :type organization_id: str
-    :param workspace_id: WorkspaceID
-    :type workspace_id: str
-
-    :rtype: InlineResponse2006
-    """
-
-    result_data = {}
-
-    return result_data,
-
-
-@api_filter
-def post_event_flow(organization_id, workspace_id, body=None):  # noqa: E501
-    """post_event_flow
-
-    検索条件を指定し、イベントフローで扱う履歴情報（イベント履歴、アクション履歴）を取得する # noqa: E501
-
-    :param organization_id: OrganizationID
-    :type organization_id: str
-    :param workspace_id: WorkspaceID
-    :type workspace_id: str
-    :param body:
-    :type body: dict | bytes
-
-    :rtype: InlineResponse20022
-    """
-
-    result_data = {}
-
-    return result_data,
-
-
-@api_filter
-def post_event_flow_history(organization_id, workspace_id, body=None):  # noqa: E501
-    """post_event_flow_history
-
-    検索条件を指定し、イベントフロー画面に描画する情報を取得する # noqa: E501
-
-    :param organization_id: OrganizationID
-    :type organization_id: str
-    :param workspace_id: WorkspaceID
-    :type workspace_id: str
-    :param body:
-    :type body: dict | bytes
-
-    :rtype: InlineResponse20022
-    """
-
-    wsDb = DBConnectWs(workspace_id=workspace_id)
-    wsMongo = MONGOConnectWs()
-
-    parameter = {}
-    if connexion.request.is_json:
-        parameter = dict(connexion.request.get_json())
-
-    event_history = event_relay.collect_event_history(wsMongo, parameter)
-    action_history = event_relay.collect_action_log(wsDb, parameter)
-
-    history_data = event_relay.create_history_list(event_history, action_history)
-
-    return history_data,
-
-
-@api_filter
-def get_event_flow_definition(organization_id, workspace_id):  # noqa: E501
-    """get_event_flow_definition
-
-    イベントフローで扱う定義情報（ラベル、アクション、ルール）を取得する
-
-    :param organization_id: OrganizationID
-    :type organization_id: str
-    :param workspace_id: WorkspaceID
-    :type workspace_id: str
-
-    :rtype: InlineResponse20023
-    """
-
-    wsDb = DBConnectWs(workspace_id=workspace_id)
-
-    result_data = {}
-
-    result_data["filter"] = event_relay.collect_filter(wsDb)
-    result_data["action"] = event_relay.collect_action(wsDb)
-    result_data["rule"] = event_relay.collect_rule(wsDb)
-
     return result_data,

--- a/ita_root/ita_api_organization/openapi.yaml
+++ b/ita_root/ita_api_organization/openapi.yaml
@@ -5854,7 +5854,7 @@ paths:
       tags:
         - Event Relay
       description: 検索条件を指定し、イベントフローで扱う履歴情報（イベント履歴、アクション履歴）を取得する
-      operationId: postEventFlow
+      operationId: postEventFlowHistory
       x-openapi-router-controller: controllers.event_relay_controller
       parameters:
         - name: organization_id

--- a/ita_root/ita_api_organization/swagger/swagger.yaml
+++ b/ita_root/ita_api_organization/swagger/swagger.yaml
@@ -5187,25 +5187,7 @@ paths:
         content:
           application/json:
             schema:
-              description: 検索条件を指定
-              properties:
-                start_time:
-                  type: string
-                  format: date-time
-                  example: "2017-07-21T17:32:28Z"
-                end_time:
-                  type: string
-                  format: date-time
-                  example: "2017-07-21T17:32:28Z"
-                evaluted:
-                  type: boolean
-                  example: "true"
-                undetected:
-                  type: boolean
-                  example: "false"
-                timeouted:
-                  type: boolean
-                  example: "false"
+              $ref: '#/components/schemas/event_flow_history_body'
       responses:
         "200":
           description: Success
@@ -5945,7 +5927,7 @@ components:
           type: string
       example:
         result: 000-00000
-        data: 0.80082819046101150206595775671303272247314453125
+        data: 0.8008281904610115
         message: message
     filter_count_body:
       properties:
@@ -6706,34 +6688,6 @@ components:
           file_name: "{compare_name}_YYYY/MMDDhhmmss.xlsx"
           file_data: Compare result base64 string
         message: message
-    inline_response_200_22:
-      type: object
-      properties:
-        result:
-          type: string
-          example: 000-00000
-        data:
-          $ref: '#/components/schemas/inline_response_200_22_data'
-        message:
-          type: string
-      example:
-        result: 000-00000
-        data: []
-        message: message
-    inline_response_200_23:
-      type: object
-      properties:
-        result:
-          type: string
-          example: 000-00000
-        data:
-          $ref: '#/components/schemas/inline_response_200_23_data'
-        message:
-          type: string
-      example:
-        result: 000-00000
-        data: {"action":[{}], "filter":[{}], "rule":[{}] }
-        message: message
     execute_file_body:
       properties:
         compare:
@@ -6793,6 +6747,70 @@ components:
         rest_key_name:
           $ref: '#/components/schemas/FILTER_REQUEST_PARAMETERS'
       description: 検索条件を設定
+    event_flow_history_body:
+      properties:
+        start_time:
+          type: string
+          format: date-time
+          example: 2017-07-21T17:32:28Z
+        end_time:
+          type: string
+          format: date-time
+          example: 2017-07-21T17:32:28Z
+        evaluted:
+          type: boolean
+          example: true
+        undetected:
+          type: boolean
+          example: false
+        timeouted:
+          type: boolean
+          example: false
+      description: 検索条件を指定
+    inline_response_200_22:
+      type: object
+      properties:
+        result:
+          type: string
+          example: 000-00000
+        data:
+          type: array
+          example: []
+          items:
+            $ref: '#/components/schemas/inline_response_200_22_data'
+        message:
+          type: string
+      example:
+        result: 000-00000
+        data: []
+        message: message
+    inline_response_200_23:
+      type: object
+      properties:
+        result:
+          type: string
+          example: 000-00000
+        data:
+          type: object
+          example:
+            action:
+            - {}
+            filter:
+            - {}
+            rule:
+            - {}
+        message:
+          type: string
+      example:
+        result: 000-00000
+        data:
+          action:
+          - {}
+          filter:
+          - {}
+          rule:
+          - {}
+        message: message
     FILTER_REQUEST_PARAMETERS_RANGE:
       type: object
       properties:
@@ -7447,36 +7465,17 @@ components:
     inline_response_200_22_data:
       type: object
       properties:
-        data:
-          type: array
-          items:
-            example: イベント履歴とアクション履歴をまとめて日時の昇順でソートした一覧
-      example:
-    inline_response_200_23_data:
-      type: object
-      properties:
-        data:
+        datetime:
+          type: string
+          example: 2023-09-12 15:41:29
+        id:
+          type: string
+        item:
           type: object
-          properties:
-            action:
-              type: array
-              items:
-                type: object
-                example:
-                - アクション定義のカラム名
-            filter:
-              type: array
-              items:
-                type: object
-                example:
-                - フィルター管理のカラム名
-            rule:
-              type: array
-              items:
-                type: object
-                example:
-                - ルール管理のカラム名
-      example:
+          description: イベント履歴かアクション履歴から取得した内容
+        type:
+          type: string
+          description: "取得元を判断するための文字列。イベント履歴：event, アクション履歴：action"
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid


### PR DESCRIPTION
# 概要
以下4点の対応を実施
 - operationIdの記載を誤っていたのでopenapi.yamlを修正
 - swagger.yamlを手作業で修正していたので、Swagger EditorでGenerateしたファイルに差し替え
 - event_relay_controller.pyから不要となった関数定義を削除
 - event_relay_controller.pyの関数の並び順をSwagger EditorでGenerateしたファイルと一致させるように並び替え