### PR TITLE
既存APIにイベント履歴画面向けの処理を追加

### DIFF
--- a/ita_root/common_libs/common/menu_info.py
+++ b/ita_root/common_libs/common/menu_info.py
@@ -19,6 +19,7 @@ from common_libs.common import *  # noqa: F403
 from common_libs.loadtable import *  # noqa: F403
 from common_libs.column import *  # noqa: F403
 from flask import g
+from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs, CollectionFactory
 
 
 def collect_menu_info(objdbca, menu, menu_record={}, menu_table_link_record={}, privilege='1'):  # noqa: C901
@@ -670,3 +671,40 @@ def collect_search_candidates(objdbca, menu, column, menu_record={}, menu_table_
         search_candidates = list(dict.fromkeys(search_candidates))
 
     return search_candidates
+
+
+def collect_search_candidates_from_mongodb(wsMongo: MONGOConnectWs, column, menu_record, menu_table_link_record):
+    """
+    Args:
+        wsMongo (MONGOConnectWs): DB接続クラス  MONGOConnectWs()
+        column: REST API項目名
+        menu_record: メニュー管理のレコード
+        menu_table_link_record: メニュー-テーブル紐付管理のレコード
+    Returns:
+        search_candidates
+    """
+
+    # メニュー-テーブル紐付管理はMariaDBのテーブル名を保持するのでそのままでは利用できないため、MongoDBのコレクション名に変換する
+    mariadb_table_name = menu_table_link_record["TABLE_NAME"]
+    mondodb_collection_name = CollectionFactory.get_collection_name(mariadb_table_name)
+    collection = CollectionFactory.create(mondodb_collection_name)
+
+    # MongoDB向けの記法に変換が必要なため、DBから取得した値はそのまま利用しない
+    sort_key = collection.create_sort_key(menu_record["SORT_KEY"])
+
+    # filter向けに用意した処理を流用し、python側で絞り込んだ方が実装工数が短くなるため一旦この実装とする。
+    # MongoDBから扱わない項目も取得しているため、その分のコストが重い場合は専用の実装を検討する。
+    tmp_result = (wsMongo.collection(mondodb_collection_name)
+                  .find()
+                  .sort(sort_key))
+    result_list = collection.create_result(tmp_result)
+    search_candidates = [item.get(column) for item in result_list]
+
+    # 重複を排除したリストを作成
+    # 値がobjectの可能性もあるため詰めなおす方式で実装
+    result = []
+    for item in search_candidates:
+        if item not in result:
+            result.append(item)
+
+    return result

--- a/ita_root/common_libs/common/mongoconnect/collection/__init__.py
+++ b/ita_root/common_libs/common/mongoconnect/collection/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 NEC Corporation#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .labeled_event_collection import *  # noqa: F403,F401

--- a/ita_root/common_libs/common/mongoconnect/collection/labeled_event_collection.py
+++ b/ita_root/common_libs/common/mongoconnect/collection/labeled_event_collection.py
@@ -1,0 +1,211 @@
+# Copyright 2023 NEC Corporation#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import datetime
+
+from bson.objectid import ObjectId
+from common_libs.common.mongoconnect.collection_base import CollectionBase
+
+
+class LabeledEventCollection(CollectionBase):
+    """
+    LabeledEventCollection
+
+        labeled_event_collectionの検索条件を生成するクラス
+
+    """
+
+    RANGE_LIST = [
+        "_exastro_fetched_time",
+        "_exastro_end_time"
+    ]
+
+    def _is_separated_supported_item(self, rest_key_name, type):
+        # _exastro_event_statusにLISTが指定された場合$orを使用する必要があるため個別対応とした
+        if rest_key_name == "_exastro_event_status" and type == "LIST":
+            return True
+
+        return False
+
+    def _convert_parameter_item_name_to_collection_item_name(self, rest_key_name, value):
+        tmp_item_name = super()._convert_parameter_item_name_to_collection_item_name(rest_key_name, value)
+
+        simple_convert_map = {
+            "_exastro_event_collection_settings_id": ["labels._exastro_event_collection_settings_id"],
+            "_exastro_fetched_time": ["labels._exastro_fetched_time"],
+            "_exastro_end_time": ["labels._exastro_end_time"],
+            "_exastro_type": ["labels._exastro_type"],
+            "_exastro_rule_name": ["exastro_rule.name"],
+            "_exastro_events": ["exastro_events"],
+            "_exastro_event_status": ["labels._exastro_time_out", "labels._exastro_evaluated", "labels._exastro_undetected"]
+        }
+
+        if rest_key_name in simple_convert_map:
+            return simple_convert_map[rest_key_name]
+
+        return tmp_item_name
+
+    def _create_search_value(self, collection_item_name, value):
+        tmp_value = super()._create_search_value(collection_item_name, value)
+
+        if collection_item_name == "labels._exastro_fetched_time":
+            return str(int(datetime.datetime.strptime(tmp_value, '%Y-%m-%dT%H:%M:%S%z').timestamp()))
+
+        if collection_item_name == "labels._exastro_end_time":
+            return str(int(datetime.datetime.strptime(tmp_value, '%Y-%m-%dT%H:%M:%S%z').timestamp()))
+
+        if collection_item_name == "labels._exastro_time_out":
+            if value == "時間切れ":
+                return "1"
+            else:
+                return "0"
+
+        if collection_item_name == "labels._exastro_evaluated":
+            if value == "ルールマッチ済み":
+                return "1"
+            else:
+                return "0"
+
+        if collection_item_name == "labels._exastro_undetected":
+            if value == "未知イベント":
+                return "1"
+            else:
+                return "0"
+
+        if collection_item_name == "labels._exastro_type":
+            if value == "イベント":
+                return "event"
+            elif value == "再評価":
+                return "conclusion"
+
+        if collection_item_name == "exastro_events":
+            return ObjectId(tmp_value)
+
+        return tmp_value
+
+    def _create_separated_supported_search_value(self, rest_key_name, type, value):
+        # _exastro_event_statusにLISTが指定された場合$orを使用する必要があるため個別対応とした
+        if rest_key_name == "_exastro_event_status" and type == "LIST":
+            tmp_list: list = value
+            if len(tmp_list) == 1:
+
+                return self.__create_exastro_event_status_search_value(tmp_list[0])
+
+            elif len(tmp_list) > 1:
+                result_list = []
+                for item in tmp_list:
+                    result_list.append(self.__create_exastro_event_status_search_value(item))
+
+                return {"$or": result_list}
+
+            else:
+                return {}
+
+        return {rest_key_name: value}
+
+    def __create_exastro_event_status_search_value(self, item):
+        if item == "検討中":
+            return {
+                "labels._exastro_time_out": "0",
+                "labels._exastro_evaluated": "0",
+                "labels._exastro_undetected": "0"
+            }
+
+        elif item == "時間切れ":
+            return {
+                "labels._exastro_time_out": "1",
+                "labels._exastro_evaluated": "0",
+                "labels._exastro_undetected": "0"
+            }
+
+        elif item == "ルールマッチ済み":
+            return {
+                "labels._exastro_time_out": "0",
+                "labels._exastro_evaluated": "1",
+                "labels._exastro_undetected": "0"
+            }
+
+        elif item == "未知イベント":
+            return {
+                "labels._exastro_time_out": "0",
+                "labels._exastro_evaluated": "0",
+                "labels._exastro_undetected": "1"
+            }
+        else:
+            return {}
+
+    def _format_result_value(self, item):
+        format_item = super()._format_result_value(item)
+
+        # イベント状態の判定で使用するマップ。
+        # 判定する値は左から_exastro_time_out, _exastro_evaluated, _exastro_undetectedの順に文字列結合する想定。
+        event_status_map = {
+            "000": "検討中",
+            "001": "未知イベント",
+            "010": "ルールマッチ済み",
+            "100": "時間切れ"
+        }
+
+        # イベント種別の判定で使用するマップ
+        event_type_map = {
+            "event": "イベント",
+            "conclusion": "再評価"
+        }
+
+        # labels配下の特定項目は一段上に引き上げる必要がある。
+        # また、該当しない項目もそのままlabelsとして返却する必要がある。
+        # そのため、元のオブジェクトからはpopで値を削除し重複して表示されないようにする。
+        if "labels" in item:
+            labels = dict(item["labels"])
+
+            if "_exastro_event_collection_settings_id" in labels:
+                format_item["_exastro_event_collection_settings_id"] = labels.pop("_exastro_event_collection_settings_id")
+
+            if "_exastro_fetched_time" in labels:
+                ts = int(labels.pop("_exastro_fetched_time"))
+                dt = datetime.datetime.fromtimestamp(ts)
+                format_item["_exastro_fetched_time"] = dt.strftime("%Y/%m/%d %H:%M:%S")
+
+            if "_exastro_end_time" in labels:
+                ts = int(labels.pop("_exastro_end_time"))
+                dt = datetime.datetime.fromtimestamp(ts)
+                format_item["_exastro_end_time"] = dt.strftime("%Y/%m/%d %H:%M:%S")
+
+            # イベント状態の判定で使用する値を組み立てる。
+            # 3種とも確実に存在する前提だが、dictの存在チェックを利用する都合により取得できない場合は0を設定する。
+            tmp_status = labels.pop("_exastro_time_out") if "_exastro_time_out" in labels else '0'
+            tmp_status += labels.pop("_exastro_evaluated") if "_exastro_evaluated" in labels else '0'
+            tmp_status += labels.pop("_exastro_undetected") if "_exastro_undetected" in labels else '0'
+
+            format_item["_exastro_event_status"] = event_status_map.get(tmp_status)
+
+            if "_exastro_type" in labels:
+                format_item["_exastro_type"] = event_type_map[labels.pop("_exastro_type")]
+
+            if "_exastro_rule_name" in labels:
+                format_item["_exastro_rule_name"] = labels.pop("_exastro_rule_name")
+
+            # 残項目はlabelsとして返却するため代入する。
+            format_item["labels"] = labels
+
+        if "exastro_events" in item:
+            exastro_events = list(item["exastro_events"])
+
+            format_item["_exastro_events"] = []
+            for item in exastro_events:
+                # eventsは再評価イベントを作成するきっかけとなったイベントの_idが格納されている。
+                # そのままではJSONとして扱えないため_idと同じように変換する。
+                format_item["_exastro_events"].append(str(item))
+
+        return format_item

--- a/ita_root/common_libs/common/mongoconnect/collection_base.py
+++ b/ita_root/common_libs/common/mongoconnect/collection_base.py
@@ -1,0 +1,221 @@
+# Copyright 2023 NEC Corporation#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+
+from bson.objectid import ObjectId
+from common_libs.common.exception import AppException
+
+from .const import Const
+
+
+class CollectionBase():
+    """
+    Collection
+
+        MongoDBのコレクションに対する以下の操作を統一するための抽象クラス\n
+        ・検索条件組み立て\n
+        ・返却値整形
+
+    """
+
+    # RANGEによる検索を許可するMongoDBの項目名を保持するリスト
+    RANGE_LIST = []
+
+    def create_where(self, parameter: dict) -> dict:
+        """
+        コレクションの検索条件を作成する。
+        Arguments:
+            parameter (dict): リクエストBody
+
+        Raises:
+            NotImplementedError:
+
+        Returns:
+            dict:MongoDBの検索で使用可能な状態のDict
+        """
+        result = {}
+        for rest_key_name, setting in parameter.items():
+            for type, value in setting.items():
+
+                # 特殊な流れで処理が必要な場合の分岐
+                if self._is_separated_supported_item(rest_key_name, type):
+                    result.update(self._create_separated_supported_search_value(rest_key_name, type, value))
+
+                else:
+                    # 通常の流れで処理できる場合の分岐
+                    collection_item_name = self._convert_parameter_item_name_to_collection_item_name(rest_key_name, value)
+
+                    # 1つの条件で複数のカラムに条件指定が必要な場合を考慮してループで処理する。
+                    for item_name in collection_item_name:
+                        if type == "NORMAL":
+                            result[item_name] = self._create_search_value(item_name, value)
+
+                        elif type == "LIST":
+                            tmp_list = []
+                            for item in value:
+                                tmp_list.append(self._create_search_value(item_name, item))
+
+                            result[item_name] = {"$in": tmp_list}
+
+                        elif type == "RANGE":
+                            # RANGEに対応していない項目の場合例外として処理する。
+                            if not self.is_supported_range(rest_key_name):
+                                status_code = '499-00101'
+                                log_msg_args = [rest_key_name]
+                                api_msg_args = [rest_key_name]
+                                raise AppException(status_code, log_msg_args, api_msg_args)
+
+                            # RANGEの場合開始（START）終了（END）を指定するため、対応した比較演算子を定義する。
+                            kind_map = {
+                                "START": "$gte",
+                                "END": "$lte"
+                            }
+
+                            tmp_dict = {}
+                            for kind, item in dict(value).items():
+                                tmp_dict[kind_map[kind]] = self._create_search_value(item_name, item)
+
+                            result[item_name] = tmp_dict
+
+        return result
+
+    def _convert_parameter_item_name_to_collection_item_name(self, rest_key_name, value):
+        """
+        パラメータのKEYをMongoDBの項目名に変換する
+        特殊な変換が必要な場合はオーバーライドすること。
+        Args:
+            rest_key_name: パラメータに対応するmongoDBの項目名
+        """
+
+        return [rest_key_name]
+
+    def _create_search_value(self, collection_item_name, value):
+        """
+        受け取った値をMongoDBで検索する際に適した値に変換する。
+        共通的に処理できるのは_idのみ。
+        クラス独自の変換処理を実装する場合はオーバーライドすること。
+        Args:
+            rest_key_name: RESTAPIで返却する際のKEY
+            value: パラメータから受け取った値
+
+        Returns:
+            変換が必要な場合は変換後の値。変換が不要な場合は引数valueの値をそのまま返却する。
+        """
+
+        if collection_item_name == "_id":
+            return ObjectId(value)
+
+        return value
+
+    def _is_separated_supported_item(self, rest_key_name, type):
+        """
+        個別対応が必要な項目かどうかを確認する
+        確認はリクエストパラメータの名前とパラメータのタイプの組み合わせで行う。
+        必要に応じてオーバーライドしてTrueを返却するパターンを実装すること。
+        また項目を追加する場合は「_create_separated_supported_search_value」に同様の判定を追加すること
+
+        Args:
+            rest_key_name: パラメータ名
+            type: パラメータのタイプ（NORMAL, LIST, RANGE）
+
+        Returns:
+            _type_: _description_
+        """
+        return False
+
+    def _create_separated_supported_search_value(self, rest_key_name, type, value):
+        """
+        個別に処理が必要な検索値生成処理を定義するためのメソッド
+        必要に応じてオーバーライドして各検索値を生成する処理を実装すること。
+        また項目を追加する場合は「_create_separated_supported_search_value」に同様の判定を追加すること
+        Args:
+            rest_key_name: パラメータ名
+            type: パラメータのタイプ（NORMAL, LIST, RANGE）
+            value: パラメータの値
+        """
+
+        return {rest_key_name: value}
+
+    def is_supported_range(self, rest_key_name):
+        """
+        引数で指定された項目がRANGEの検索に対応しているかチェックする
+        Args:
+            rest_key_name: リクエストパラメータ名
+        """
+
+        return rest_key_name in self.RANGE_LIST
+
+    def create_result(self, result: list[dict]) -> dict:
+        """
+        MongoDBから取得したデータを返却するために整形する。
+        実際の値の整形は__format_result_valueで行い、ここでは流れのみを定義する。
+
+        Args:
+            parameter (dict): _description_
+
+        Returns:
+            dict: _description_
+        """
+
+        format_result = []
+        for item in result:
+            format_item = self._format_result_value(item)
+            format_result.append(format_item)
+
+        return format_result
+
+    def _format_result_value(self, item):
+        """
+        受け取った値を画面で表示する際に適した値に変換する。
+        共通的に処理できるのは_idのみ。
+        クラス独自の変換処理を実装する場合はオーバーライドすること。
+        Args:
+            rest_key_name: RESTAPIで返却する際のKEY
+            value: パラメータから受け取った値
+
+        Returns:
+            変換が必要な場合は変換後の値。変換が不要な場合は引数valueの値をそのまま返却する。
+        """
+
+        # オブジェクトの構造も変わるため、受け入れ用のオブジェクトを別途定義
+        format_item = {}
+
+        # _idについてはstrに変換（ObjectId()が無くなる）で問題ないことを確認済み。
+        format_item["_id"] = str(item["_id"])
+
+        return format_item
+
+    def create_sort_key(self, sort_key: str) -> list[tuple]:
+        """
+        ソートキーを生成する
+        コレクションを問わずこのまま使用できる想定。
+        扱う値はメニュー管理のSORT_KEYの値に依存する。
+        MariaDBのテーブルに対して設定する内容と同じ内容を設定してもらえば問題なく処理できるようになっている。
+        Arguments:
+            sort_key (str): loadTable.get_sort_key()で取得した値
+
+        Returns:
+            list[tuple]: 検索条件を設定したタプル（カラム名、ソート順）を格納したリスト
+        """
+        result = []
+        sort_key_json: list[dict] = json.loads(sort_key)
+        for item in sort_key_json:
+            for key, value in item.items():
+                if key == 'ASC':
+                    result.append((value, Const.ASCENDING))
+                elif key == 'DESC':
+                    result.append((value, Const.DESCENDING))
+
+        return result

--- a/ita_root/common_libs/common/mongoconnect/const.py
+++ b/ita_root/common_libs/common/mongoconnect/const.py
@@ -1,0 +1,38 @@
+# Copyright 2023 NEC Corporation#
+# Licensed under the Apache License, Version 2.2 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.2
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pymongo import ASCENDING, DESCENDING
+
+
+class Const:
+    """
+    MongoDBに関連する定数を定義するクラス。
+    """
+    # MongoDBからデータを取得するシートタイプID
+    MONGODB_SHEETTYPE_ID = '26'
+
+    # コレクション名
+    LABELED_EVENT_COLLECTION = "labeled_event_collection"
+
+    # テーブル名
+    T_EVENT_HISTORY = "T_EVRL_EVENT_HISTORY"
+
+    # テーブル名とコレクション名のマッピング
+    NAME_MAP: [str, str] = {
+        T_EVENT_HISTORY: LABELED_EVENT_COLLECTION
+    }
+
+    # ソート順
+    ASCENDING = ASCENDING
+    DESCENDING = DESCENDING

--- a/ita_root/common_libs/common/mongoconnect/mongoconnect.py
+++ b/ita_root/common_libs/common/mongoconnect/mongoconnect.py
@@ -23,6 +23,9 @@ from pymongo.errors import PyMongoError
 from ..dbconnect.dbconnect_org import DBConnectOrg
 from common_libs.common.exception import AppException
 from common_libs.common.util import ky_decrypt, ky_encrypt, generate_secrets
+from . import collection
+from .collection_base import CollectionBase
+from .const import Const
 
 
 class MONGOConnectRoot():
@@ -228,3 +231,53 @@ class MONGOConnectWs(MONGOConnectRoot):
 
         # connect database
         self.connect()
+
+
+class CollectionFactory():
+    """
+    CollectionFactory
+
+        CollectionBaseの具象クラスをコレクション名を与えて生成するために定義したクラス。
+        定義のメンテナンスを行う際は以下を確認すること。
+        ・CollectionFactory.FACTORY_MAP
+        ・collection/__init__.py
+        ・const.py
+
+    """
+
+    # MongoDBのコレクション名と対応するクラスの対応表
+    FACTORY_MAP: [str, CollectionBase] = {
+        Const.LABELED_EVENT_COLLECTION: collection.LabeledEventCollection
+    }
+
+    @classmethod
+    def create(cls, collection_name: str) -> CollectionBase:
+        '''
+        コレクション名に対応したCollectionBaseの具象クラスを生成する。
+        Arguments:
+            collection_name: 生成するクラスに対応したコレクション名
+
+        Raises:
+            TypeError:未定義のコレクション名を受け取った場合に発生
+
+        Returns:
+            CollectionBaseの具象クラス
+        '''
+
+        if collection_name in cls.FACTORY_MAP:
+            return cls.FACTORY_MAP[collection_name]()
+        raise TypeError
+
+    @classmethod
+    def get_collection_name(cls, table_name: str) -> str:
+        """
+        MariaDBのテーブル名に対応するMongoDBのコレクション名を返却する
+
+        Arguments:
+            mariadb_table_name (str): テーブル名
+
+        Returns:
+            str: コレクション名
+        """
+
+        return Const.NAME_MAP[table_name]

--- a/ita_root/ita_api_organization/controllers/menu_filter_controller.py
+++ b/ita_root/ita_api_organization/controllers/menu_filter_controller.py
@@ -21,6 +21,7 @@ from common_libs.loadtable.load_table import loadTable
 from common_libs.api import api_filter
 from libs.organization_common import check_menu_info, check_auth_menu, check_sheet_type
 from libs import menu_filter
+from common_libs.common.mongoconnect.const import Const
 
 
 @api_filter
@@ -40,17 +41,19 @@ def get_filter_count(organization_id, workspace_id, menu):  # noqa: E501
     """
     # DB接続
     objdbca = DBConnectWs(workspace_id)  # noqa: F405
-    
+
     # メニューの存在確認
     check_menu_info(menu, objdbca)
 
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
+    # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
+    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
-    
+
     filter_parameter = {}
     result_data = menu_filter.rest_count(objdbca, menu, filter_parameter)
     return result_data,
@@ -73,17 +76,19 @@ def get_filter(organization_id, workspace_id, menu):  # noqa: E501
     """
     # DB接続
     objdbca = DBConnectWs(workspace_id)  # noqa: F405
-    
+
     # メニューの存在確認
     check_menu_info(menu, objdbca)
 
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
+    # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
+    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
-    
+
     filter_parameter = {}
     result_data = menu_filter.rest_filter(objdbca, menu, filter_parameter)
     return result_data,
@@ -119,7 +124,7 @@ def get_journal(organization_id, workspace_id, menu, uuid):  # noqa: E501
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
-    
+
     result_data = menu_filter.rest_filter_journal(objdbca, menu, uuid)
     return result_data,
 
@@ -144,22 +149,24 @@ def post_filter(organization_id, workspace_id, menu, body=None):  # noqa: E501
 
     # DB接続
     objdbca = DBConnectWs(workspace_id)  # noqa: F405
-    
+
     # メニューの存在確認
     check_menu_info(menu, objdbca)
 
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
+    # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
+    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
-    
+
     filter_parameter = {}
     if connexion.request.is_json:
         body = dict(connexion.request.get_json())
         filter_parameter = body
-        
+
     # メニューのカラム情報を取得
     result_data = menu_filter.rest_filter(objdbca, menu, filter_parameter)
     return result_data,
@@ -184,22 +191,24 @@ def post_filter_count(organization_id, workspace_id, menu, body=None):  # noqa: 
     """
     # DB接続
     objdbca = DBConnectWs(workspace_id)  # noqa: F405
-    
+
     # メニューの存在確認
     check_menu_info(menu, objdbca)
 
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
+    # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
+    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
-    
+
     filter_parameter = {}
     if connexion.request.is_json:
         body = dict(connexion.request.get_json())
         filter_parameter = body
-        
+
     # メニューのカラム情報を取得
     result_data = menu_filter.rest_count(objdbca, menu, filter_parameter)
     return result_data,

--- a/ita_root/ita_api_organization/controllers/menu_info_controller.py
+++ b/ita_root/ita_api_organization/controllers/menu_info_controller.py
@@ -16,6 +16,8 @@ from common_libs.common import *  # noqa: F403
 from common_libs.api import api_filter
 from libs.organization_common import check_menu_info, check_auth_menu, check_sheet_type
 from common_libs.common import menu_info
+from common_libs.common.mongoconnect.const import Const
+from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 
 
 @api_filter
@@ -145,12 +147,24 @@ def get_search_candidates(organization_id, workspace_id, menu, column):  # noqa:
 
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
+    # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
+    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
     menu_table_link_record = check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
 
-    # 対象項目のプルダウン検索候補一覧を取得
-    data = menu_info.collect_search_candidates(objdbca, menu, column, menu_record, menu_table_link_record)
+    if menu_table_link_record[0]["SHEET_TYPE"] != Const.MONGODB_SHEETTYPE_ID:
+        # 対象項目のプルダウン検索候補一覧を取得
+        data = menu_info.collect_search_candidates(objdbca, menu, column, menu_record, menu_table_link_record)
+    else:
+        wsMongo = MONGOConnectWs()
+
+        # 既存処理もインデックス指定で取得しているため1レコードしか取れない前提で処理して問題ないと判断。
+        # 都度インデックス指定でアクセスするのは手間なので先頭のデータでそれぞれ変数を上書きする。
+        menu_record = menu_record[0]
+        menu_table_link_record = menu_table_link_record[0]
+
+        data = menu_info.collect_search_candidates_from_mongodb(wsMongo, column, menu_record, menu_table_link_record)
 
     return data,

--- a/ita_root/ita_api_organization/libs/menu_filter.py
+++ b/ita_root/ita_api_organization/libs/menu_filter.py
@@ -16,6 +16,8 @@ import os
 from flask import g
 
 from common_libs.common import *  # noqa: F403
+from common_libs.common.mongoconnect.const import Const
+from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 from common_libs.loadtable import *
 
 
@@ -39,12 +41,21 @@ def rest_count(objdbca, menu, filter_parameter):
         api_msg_args = ["not menu or table"]
         raise AppException("401-00001", log_msg_args, api_msg_args) # noqa: F405
 
-    status_code, result, msg = objmenu.rest_filter(filter_parameter, mode)
+    # MongoDB向けの処理はmodeで分岐させているため、対象のシートタイプの場合はmodeを上書き
+    wsMongo = None
+    if objmenu.get_sheet_type() == Const.MONGODB_SHEETTYPE_ID:
+        mode = 'mongo_count'
+
+        # MariaDBのコネクションはコントローラーで生成しているため、MongoDBも同様にすべきだが、
+        # アクセスしない場合もコネクションを生成するのは無駄が多いためここで生成することにした。
+        wsMongo = MONGOConnectWs()
+
+    status_code, result, msg = objmenu.rest_filter(filter_parameter, mode, wsMongo)
     if status_code != '000-00000':
         log_msg_args = [msg]
         api_msg_args = [msg]
         raise AppException(status_code, log_msg_args, api_msg_args)
-    
+
     return result
 
 
@@ -57,6 +68,7 @@ def rest_filter(objdbca, menu, filter_parameter):
             filter_parameter: 検索条件  {}
             lang: 言語情報 ja / en
             mode: 本体 / 履歴
+            wsMongo:DB接続クラス  MONGOConnectWs()
         RETRUN:
             statusCode, {}, msg
     """
@@ -68,12 +80,21 @@ def rest_filter(objdbca, menu, filter_parameter):
         api_msg_args = ["not menu or table"]
         raise AppException("401-00001", log_msg_args, api_msg_args) # noqa: F405
 
-    status_code, result, msg = objmenu.rest_filter(filter_parameter, mode)
+    # MongoDB向けの処理はmodeで分岐させているため、対象のシートタイプの場合はmodeを上書き
+    wsMongo = None
+    if objmenu.get_sheet_type() == Const.MONGODB_SHEETTYPE_ID:
+        mode = 'mongo'
+
+        # MariaDBのコネクションはコントローラーで生成しているため、MongoDBも同様にすべきだが、
+        # アクセスしない場合もコネクションを生成するのは無駄が多いためここで生成することにした。
+        wsMongo = MONGOConnectWs()
+
+    status_code, result, msg = objmenu.rest_filter(filter_parameter, mode, wsMongo)
     if status_code != '000-00000':
         log_msg_args = [msg]
         api_msg_args = [msg]
         raise AppException(status_code, log_msg_args, api_msg_args)
-    
+
     return result
 
 
@@ -89,7 +110,7 @@ def rest_filter_journal(objdbca, menu, uuid):
         RETRUN:
             statusCode, {}, msg
     """
-    
+
     objmenu = load_table.loadTable(objdbca, menu)
     if objmenu.get_objtable() is False:
         log_msg_args = ["not menu or table"]


### PR DESCRIPTION
# 概要
イベント履歴画面で使用するため既存APIにMongoDBからデータを取得する処理を追加しました。

## 詳細
今回処理を追加したのは以下のAPIです。
- Menu Info
  - GET /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/info/search/candidates/{column}/
- Menu Filter
  - GET /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/filter/count/
  - POST /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/filter/count/
  - GET /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/filter/
  - POST /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/filter/


