### PR TITLE
MongoDB向けのプルダウン取得APIの処理を修正

### DIFF
--- a/ita_root/common_libs/common/menu_info.py
+++ b/ita_root/common_libs/common/menu_info.py
@@ -712,7 +712,10 @@ def collect_search_candidates_from_mongodb(wsMongo: MONGOConnectWs, column, menu
             for key, value in item.items():
                 # 一旦入れ子のdictやlistの値は取得せず、単純に文字列に変換する実装とする
                 # 入れ子の値も分解してプルダウンの項目にする場合は要追加実装
-                tmp_str = '"' + key + '": "' + str(value) + '"'
+                if isinstance(value, str):
+                    tmp_str = '"' + key + '": "' + str(value) + '"'
+                else:
+                    tmp_str = '"' + key + '": ' + json.dumps(value)
 
                 if tmp_str not in result:
                     result.append(tmp_str)
@@ -722,7 +725,13 @@ def collect_search_candidates_from_mongodb(wsMongo: MONGOConnectWs, column, menu
                 if value not in result:
                     # 一旦入れ子のdictやlistの値は取得せず、単純に文字列に変換する実装とする
                     # 入れ子の値も分解してプルダウンの項目にする場合は要追加実装
-                    result.append(str(value))
+                    if isinstance(value, dict):
+                        result.append(json.dumps(value))
+                    elif isinstance(value, list):
+                        result.append(json.dumps(value))
+                    else:
+                        result.append(value)
+
         else:
             if item not in result:
                 result.append(item)


### PR DESCRIPTION
# 概要
MongoDB向けのプルダウン取得APIの動作確認にて取得した値をそのまま条件として使用できない不備が見つかったので修正を行いました。

## 詳細
- MongoDBから取得した値の型がdictの場合、さらにdictのvalueの型を判定し、その型に応じて値を設定するように分岐を変更。
  - stringの場合、値の前後にダブルクォーテーションを付加する。
  - string以外の場合、json.dumpsで取得した値を設定する。
- MongoDBから取得した値の型がlistの場合、listの中の値の型を判定し、その型に応じて値を設定するように分岐を変更。
  - dict, listの場合、json.dumsで取得した値を設定する。
  - dict, list以外の場合、取得した値をそのまま設定する。
- MongoDBから取得した値の型がdict, list以外の場合、取得した値をそのまま設定する。