### PR TITLE
exastro-suite#1411 必要な個所でのみpymongoを利用するように定義を見直し

### DIFF
--- a/ita_root/common_libs/common/menu_info.py
+++ b/ita_root/common_libs/common/menu_info.py
@@ -20,7 +20,7 @@ from common_libs.common import *  # noqa: F403
 from common_libs.loadtable import *  # noqa: F403
 from common_libs.column import *  # noqa: F403
 from flask import g
-from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs, CollectionFactory
+from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 
 
 def collect_menu_info(objdbca, menu, menu_record={}, menu_table_link_record={}, privilege='1'):  # noqa: C901
@@ -801,8 +801,8 @@ def collect_search_candidates_from_mongodb(wsMongo: MONGOConnectWs, column, menu
 
     # メニュー-テーブル紐付管理はMariaDBのテーブル名を保持するのでそのままでは利用できないため、MongoDBのコレクション名に変換する
     mariadb_table_name = menu_table_link_record["TABLE_NAME"]
-    mondodb_collection_name = CollectionFactory.get_collection_name(mariadb_table_name)
-    collection = CollectionFactory.create(mondodb_collection_name)
+    mondodb_collection_name = wsMongo.get_collection_name(mariadb_table_name)
+    collection = wsMongo.create_collection(mondodb_collection_name)
 
     # MongoDB向けの記法に変換が必要なため、DBから取得した値はそのまま利用しない
     sort_key = collection.create_sort_key(menu_record["SORT_KEY"])

--- a/ita_root/common_libs/common/mongoconnect/mongoconnect.py
+++ b/ita_root/common_libs/common/mongoconnect/mongoconnect.py
@@ -232,26 +232,7 @@ class MONGOConnectWs(MONGOConnectRoot):
         # connect database
         self.connect()
 
-
-class CollectionFactory():
-    """
-    CollectionFactory
-
-        CollectionBaseの具象クラスをコレクション名を与えて生成するために定義したクラス。
-        定義のメンテナンスを行う際は以下を確認すること。
-        ・CollectionFactory.FACTORY_MAP
-        ・collection/__init__.py
-        ・const.py
-
-    """
-
-    # MongoDBのコレクション名と対応するクラスの対応表
-    FACTORY_MAP: [str, CollectionBase] = {
-        Const.LABELED_EVENT_COLLECTION: collection.LabeledEventCollection
-    }
-
-    @classmethod
-    def create(cls, collection_name: str) -> CollectionBase:
+    def create_collection(self, collection_name: str):
         '''
         コレクション名に対応したCollectionBaseの具象クラスを生成する。
         Arguments:
@@ -264,20 +245,65 @@ class CollectionFactory():
             CollectionBaseの具象クラス
         '''
 
-        if collection_name in cls.FACTORY_MAP:
-            return cls.FACTORY_MAP[collection_name]()
-        raise TypeError
+        return self.CollectionFactory.create(collection_name)
 
-    @classmethod
-    def get_collection_name(cls, table_name: str) -> str:
+    def get_collection_name(self, table_name):
         """
         MariaDBのテーブル名に対応するMongoDBのコレクション名を返却する
 
         Arguments:
-            mariadb_table_name (str): テーブル名
+            table_name (str): MariaDBのテーブル名
 
         Returns:
             str: コレクション名
         """
+        return self.CollectionFactory.get_collection_name(table_name)
 
-        return Const.NAME_MAP[table_name]
+    class CollectionFactory():
+        """
+        CollectionFactory
+        利便性を考慮してMONGOConnectWsのインナークラスとして定義
+            CollectionBaseの具象クラスをコレクション名を与えて生成するために定義したクラス。
+            定義のメンテナンスを行う際は以下を確認すること。
+            ・CollectionFactory.FACTORY_MAP
+            ・collection/__init__.py
+            ・const.py
+
+        """
+
+        # MongoDBのコレクション名と対応するクラスの対応表
+        FACTORY_MAP: [str, CollectionBase] = {
+            Const.LABELED_EVENT_COLLECTION: collection.LabeledEventCollection
+        }
+
+        @classmethod
+        def create(cls, collection_name: str) -> CollectionBase:
+            '''
+            コレクション名に対応したCollectionBaseの具象クラスを生成する。
+            Arguments:
+                collection_name: 生成するクラスに対応したコレクション名
+
+            Raises:
+                TypeError:未定義のコレクション名を受け取った場合に発生
+
+            Returns:
+                CollectionBaseの具象クラス
+            '''
+
+            if collection_name in cls.FACTORY_MAP:
+                return cls.FACTORY_MAP[collection_name]()
+            raise TypeError
+
+        @classmethod
+        def get_collection_name(cls, table_name: str) -> str:
+            """
+            MariaDBのテーブル名に対応するMongoDBのコレクション名を返却する
+
+            Arguments:
+                table_name (str): テーブル名
+
+            Returns:
+                str: コレクション名
+            """
+
+            return Const.NAME_MAP[table_name]

--- a/ita_root/common_libs/loadtable/load_table.py
+++ b/ita_root/common_libs/loadtable/load_table.py
@@ -24,7 +24,6 @@ import re
 from flask import g
 from common_libs.column import *  # noqa: F403
 from common_libs.common import *  # noqa: F403
-from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs, CollectionFactory
 
 
 # 定数
@@ -900,7 +899,7 @@ class loadTable():
         return result
 
     # [filter]:メニューのレコード取得
-    def rest_filter(self, parameter, mode='nomal', wsMongo: MONGOConnectWs = None):
+    def rest_filter(self, parameter, mode='nomal', wsMongo=None):
         """
             RESTAPI[filter]:メニューのレコード取得
             ARGS:
@@ -1114,8 +1113,8 @@ class loadTable():
                 # get_table_nameではMariaDB側のテーブル名が取得されるためそのまま利用はできない。
                 # get_table_nameで取得した値をMongoDBのコレクション名に変換が必要
                 mariadb_table_name = self.get_table_name()
-                mondodb_collection_name = CollectionFactory.get_collection_name(mariadb_table_name)
-                collection = CollectionFactory.create(mondodb_collection_name)
+                mondodb_collection_name = wsMongo.get_collection_name(mariadb_table_name)
+                collection = wsMongo.create_collection(mondodb_collection_name)
 
                 where_str = collection.create_where(parameter)
 


### PR DESCRIPTION
# 概要
pymongoを利用しないコンテナにて未インストールによるエラーが発生していたため、必要なパスでのみ要求されるように修正を実施。
また利便性を考慮して、CollectionFactoryをMONGOConnectWsのインナークラスに変更し、MONGOConnectWsからCollectionFactoryの処理を利用できるようにラッパーメソッドを追加