### PR TITLE
#1411 load_tableからMongoDBを利用する処理を分離し専用クラスとして定義

### DIFF
--- a/ita_root/common_libs/loadcollection/load_collection.py
+++ b/ita_root/common_libs/loadcollection/load_collection.py
@@ -1,0 +1,78 @@
+# Copyright 2023 NEC Corporation#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from common_libs.common.exception import AppException
+
+
+class loadCollection():
+    """
+    MongoDBからデータを抽出する際の振る舞いを定義するクラス。
+    loadTableの一部処理も利用するため、loadTableのインスタンスを引数で受け取っている。
+    """
+
+    def __init__(self, wsMongo, load_table):
+        """
+        初期化処理
+        Args:
+            wsMongo: MongoDBのコネクション
+            load_table: loadTableのクラス
+        """
+        self.wsMongo = wsMongo
+        self.load_table = load_table
+
+    def rest_filter(self, parameter, mode):
+        """
+            RESTAPI[filter]:メニューのレコード取得
+            ARGS:
+                parameter:検索条件
+                mode
+                    mongo:本体
+                    count:件数
+            RETRUN:
+                status_code, result, msg,
+        """
+        status_code = '000-00000'  # 成功
+        msg = ''
+        result_list = []
+
+        try:
+            # get_table_nameではMariaDB側のテーブル名が取得されるためそのまま利用はできない。
+            # get_table_nameで取得した値をMongoDBのコレクション名に変換が必要
+            mariadb_table_name = self.load_table.get_table_name()
+            mondodb_collection_name = self.wsMongo.get_collection_name(mariadb_table_name)
+            collection = self.wsMongo.create_collection(mondodb_collection_name)
+
+            where_str = collection.create_where(parameter)
+
+            # MongoDB向けの記法に変換が必要なため、DBから取得した値はそのまま利用しない
+            sort_key = collection.create_sort_key(self.load_table.get_sort_key())
+
+            if mode in ['mongo']:
+                tmp_result = (self.wsMongo.collection(mondodb_collection_name)
+                              .find(where_str)
+                              .sort(sort_key))
+
+                result_list = collection.create_result(tmp_result)
+
+            elif mode in ['mongo_count']:
+                tmp_result = (self.wsMongo.collection(mondodb_collection_name)
+                              .count_documents(where_str))
+
+                result_list = tmp_result
+
+        except AppException as e:
+            raise e
+        finally:
+            result = result_list
+        return status_code, result, msg,

--- a/ita_root/common_libs/loadtable/load_table.py
+++ b/ita_root/common_libs/loadtable/load_table.py
@@ -899,7 +899,7 @@ class loadTable():
         return result
 
     # [filter]:メニューのレコード取得
-    def rest_filter(self, parameter, mode='nomal', wsMongo=None):
+    def rest_filter(self, parameter, mode='nomal'):
         """
             RESTAPI[filter]:メニューのレコード取得
             ARGS:
@@ -910,7 +910,6 @@ class loadTable():
                     nomal:本体 / jnl:履歴 / jnl_all:履歴 /
                     excel:本体Excel用 / excel_jnl:履歴Excel用 / excel_jnl_all:全履歴Excel用 /
                     count:件数 / count_jnl:履歴件数 / count_jnl_all:全履歴件数
-                wsMongo:DB接続クラス  MONGOConnectWs()
             RETRUN:
                 status_code, result, msg,
         """
@@ -1109,17 +1108,6 @@ class loadTable():
                 if sort_key is not None:
                     str_orderby = ''
                     where_str = where_str + str_orderby
-            elif mode in ['mongo', 'mongo_count']:
-                # get_table_nameではMariaDB側のテーブル名が取得されるためそのまま利用はできない。
-                # get_table_nameで取得した値をMongoDBのコレクション名に変換が必要
-                mariadb_table_name = self.get_table_name()
-                mondodb_collection_name = wsMongo.get_collection_name(mariadb_table_name)
-                collection = wsMongo.create_collection(mondodb_collection_name)
-
-                where_str = collection.create_where(parameter)
-
-                # MongoDB向けの記法に変換が必要なため、DBから取得した値はそのまま利用しない
-                sort_key = collection.create_sort_key(self.get_sort_key())
 
             if mode in ['inner', 'nomal', 'excel', 'jnl', 'excel_jnl', 'jnl_all', 'excel_jnl_all']:
                 # データ取得
@@ -1138,18 +1126,6 @@ class loadTable():
             elif mode in ['count', 'count_jnl', 'jnl_count_all']:
                 # 件数取得
                 tmp_result = self.objdbca.table_count(table_name, where_str, bind_value_list)
-                result_list = tmp_result
-            elif mode in ['mongo']:
-                tmp_result = (wsMongo.collection(mondodb_collection_name)
-                              .find(where_str)
-                              .sort(sort_key))
-
-                result_list = collection.create_result(tmp_result)
-
-            elif mode in ['mongo_count']:
-                tmp_result = (wsMongo.collection(mondodb_collection_name)
-                              .count_documents(where_str))
-
                 result_list = tmp_result
 
         except AppException as e:

--- a/ita_root/ita_api_organization/controllers/menu_filter_controller.py
+++ b/ita_root/ita_api_organization/controllers/menu_filter_controller.py
@@ -48,7 +48,8 @@ def get_filter_count(organization_id, workspace_id, menu):  # noqa: E501
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
     # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
-    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
+    # 26 : MongoDBを利用するシートタイプ
+    sheet_type_list.append('26')
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
@@ -83,7 +84,8 @@ def get_filter(organization_id, workspace_id, menu):  # noqa: E501
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
     # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
-    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
+    # 26 : MongoDBを利用するシートタイプ
+    sheet_type_list.append('26')
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
@@ -156,7 +158,8 @@ def post_filter(organization_id, workspace_id, menu, body=None):  # noqa: E501
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
     # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
-    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
+    # 26 : MongoDBを利用するシートタイプ
+    sheet_type_list.append('26')
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
@@ -198,7 +201,8 @@ def post_filter_count(organization_id, workspace_id, menu, body=None):  # noqa: 
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
     # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
-    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
+    # 26 : MongoDBを利用するシートタイプ
+    sheet_type_list.append('26')
     check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック

--- a/ita_root/ita_api_organization/controllers/menu_info_controller.py
+++ b/ita_root/ita_api_organization/controllers/menu_info_controller.py
@@ -16,7 +16,6 @@ from common_libs.common import *  # noqa: F403
 from common_libs.api import api_filter
 from libs.organization_common import check_menu_info, check_auth_menu, check_sheet_type
 from common_libs.common import menu_info
-from common_libs.common.mongoconnect.const import Const
 from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 
 
@@ -152,13 +151,15 @@ def get_search_candidates(organization_id, workspace_id, menu, column):  # noqa:
     # 『メニュー-テーブル紐付管理』の取得とシートタイプのチェック
     sheet_type_list = ['0', '1', '2', '3', '4', '5', '6']
     # MongoDBからデータを取得するシートタイプを追加。後から追加したことを示すためあえてappendしている。
-    sheet_type_list.append(Const.MONGODB_SHEETTYPE_ID)
+    # 26 : MongoDBを利用するシートタイプ
+    sheet_type_list.append('26')
     menu_table_link_record = check_sheet_type(menu, sheet_type_list, objdbca)
 
     # メニューに対するロール権限をチェック
     check_auth_menu(menu, objdbca)
 
-    if menu_table_link_record[0]["SHEET_TYPE"] != Const.MONGODB_SHEETTYPE_ID:
+    # MongoDB向けの処理かどうかで分岐
+    if menu_table_link_record[0]["SHEET_TYPE"] != '26':
         # 対象項目のプルダウン検索候補一覧を取得
         data = menu_info.collect_search_candidates(objdbca, menu, column, menu_record, menu_table_link_record)
     else:

--- a/ita_root/ita_api_organization/controllers/menu_info_controller.py
+++ b/ita_root/ita_api_organization/controllers/menu_info_controller.py
@@ -159,10 +159,7 @@ def get_search_candidates(organization_id, workspace_id, menu, column):  # noqa:
     check_auth_menu(menu, objdbca)
 
     # MongoDB向けの処理かどうかで分岐
-    if menu_table_link_record[0]["SHEET_TYPE"] != '26':
-        # 対象項目のプルダウン検索候補一覧を取得
-        data = menu_info.collect_search_candidates(objdbca, menu, column, menu_record, menu_table_link_record)
-    else:
+    if menu_table_link_record[0]["SHEET_TYPE"] == '26':
         wsMongo = MONGOConnectWs()
 
         # 既存処理もインデックス指定で取得しているため1レコードしか取れない前提で処理して問題ないと判断。
@@ -171,5 +168,9 @@ def get_search_candidates(organization_id, workspace_id, menu, column):  # noqa:
         menu_table_link_record = menu_table_link_record[0]
 
         data = menu_info.collect_search_candidates_from_mongodb(wsMongo, column, menu_record, menu_table_link_record)
+
+    else:
+        # 対象項目のプルダウン検索候補一覧を取得
+        data = menu_info.collect_search_candidates(objdbca, menu, column, menu_record, menu_table_link_record)
 
     return data,

--- a/ita_root/ita_api_organization/libs/menu_filter.py
+++ b/ita_root/ita_api_organization/libs/menu_filter.py
@@ -19,6 +19,7 @@ from common_libs.common import *  # noqa: F403
 from common_libs.common.mongoconnect.const import Const
 from common_libs.common.mongoconnect.mongoconnect import MONGOConnectWs
 from common_libs.loadtable import *
+from common_libs.loadcollection.load_collection import loadCollection
 
 
 def rest_count(objdbca, menu, filter_parameter):
@@ -42,15 +43,19 @@ def rest_count(objdbca, menu, filter_parameter):
         raise AppException("401-00001", log_msg_args, api_msg_args) # noqa: F405
 
     # MongoDB向けの処理はmodeで分岐させているため、対象のシートタイプの場合はmodeを上書き
+    # 26 : MongoDBを利用するシートタイプ
     wsMongo = None
-    if objmenu.get_sheet_type() == Const.MONGODB_SHEETTYPE_ID:
+    if objmenu.get_sheet_type() == '26':
         mode = 'mongo_count'
 
         # MariaDBのコネクションはコントローラーで生成しているため、MongoDBも同様にすべきだが、
         # アクセスしない場合もコネクションを生成するのは無駄が多いためここで生成することにした。
         wsMongo = MONGOConnectWs()
+        load_collection = loadCollection(wsMongo, objmenu)
+        status_code, result, msg = load_collection.rest_filter(filter_parameter, mode)
+    else:
+        status_code, result, msg = objmenu.rest_filter(filter_parameter, mode)
 
-    status_code, result, msg = objmenu.rest_filter(filter_parameter, mode, wsMongo)
     if status_code != '000-00000':
         log_msg_args = [msg]
         api_msg_args = [msg]
@@ -82,14 +87,18 @@ def rest_filter(objdbca, menu, filter_parameter):
 
     # MongoDB向けの処理はmodeで分岐させているため、対象のシートタイプの場合はmodeを上書き
     wsMongo = None
-    if objmenu.get_sheet_type() == Const.MONGODB_SHEETTYPE_ID:
+    if objmenu.get_sheet_type() == '26':
         mode = 'mongo'
 
         # MariaDBのコネクションはコントローラーで生成しているため、MongoDBも同様にすべきだが、
         # アクセスしない場合もコネクションを生成するのは無駄が多いためここで生成することにした。
         wsMongo = MONGOConnectWs()
+        load_collection = loadCollection(wsMongo, objmenu)
+        status_code, result, msg = load_collection.rest_filter(filter_parameter, mode)
 
-    status_code, result, msg = objmenu.rest_filter(filter_parameter, mode, wsMongo)
+    else:
+        status_code, result, msg = objmenu.rest_filter(filter_parameter, mode)
+
     if status_code != '000-00000':
         log_msg_args = [msg]
         api_msg_args = [msg]


### PR DESCRIPTION
# 概要
MongoDBを利用する処理をload_tableに追加したがあまりload_tableの処理を利用していなかったため、分離し別クラスとして再定義を実施。
一部利用していたload_tableの処理については継承せず、load_tableのインスタンスを経由して利用する実装とした。

## 詳細
- load_collection.py
  - load_tableから分離した処理でクラスを定義
- load_table.py
  - MongoDBに関する処理を削除（修正範囲はrest_filterのみ）
- menu_filter_controller.py
  - Constを使用していた箇所を既存にならい文字リテラルに置き換え（別途文字リテラルを捕捉するコメントも追加）
- menu_info_controller.py
  - Constを使用していた箇所を既存にならい文字リテラルに置き換え（別途文字リテラルを捕捉するコメントも追加）
- menu_filter.py
 - シートタイプに応じて「load_collection」と「load_table」の利用を切り替える分岐を追加

