### PR TITLE
#1411 Platform向けに利用している通知先を取得するAPIの定義を追加

### DIFF
--- a/ita_root/ita_api_admin/controllers/menu_info_controller.py
+++ b/ita_root/ita_api_admin/controllers/menu_info_controller.py
@@ -1,0 +1,36 @@
+#   Copyright 2023 NEC Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+controller
+menu_info_controller
+"""
+
+
+def get_notification_destination(organization_id, workspace_id, menu, column):  # noqa: E501
+    """get_notification_destination
+
+    指定のメニューのカラムで利用している通知先を取得する # noqa: E501
+
+    :param organization_id: OrganizationID
+    :type organization_id: str
+    :param workspace_id: WorkspaceID
+    :type workspace_id: str
+    :param menu: メニュー名
+    :type menu: str
+    :param column: REST用項目名
+    :type column: str
+
+    :rtype: InlineResponse2005
+    """
+    return 'do some magic!'

--- a/ita_root/ita_api_admin/openapi.yaml
+++ b/ita_root/ita_api_admin/openapi.yaml
@@ -39,6 +39,8 @@ tags:
     description: ログレベル設定
   - name: Backyard Execute Check
     description: バックヤード実行状態一括取得
+  - name: Menu Info
+    description: メニュー情報の取得(Exastro Platform連携用) ※利用不可
 
 paths:
   /api/organizations/{organization_id}/ita/:
@@ -734,6 +736,68 @@ paths:
                                     last_update_timestamp:
                                       type: string
                                       example: "YYYY-MM-DD hh:mm:ss.xxxxxx"
+                  message:
+                    type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+
+  /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/info/notification/destination/{column}/:
+    get:
+      tags:
+        - Backyard Execute Check
+      description: 指定のメニューのカラムで利用している通知先を取得する
+      operationId: getNotificationDestination
+      x-openapi-router-controller: controllers.menu_info_controller
+      parameters:
+        - name: organization_id
+          in: path
+          description: OrganizationID
+          required: true
+          schema:
+            type: string
+        - name: workspace_id
+          in: path
+          description: WorkspaceID
+          required: true
+          schema:
+            type: string
+        - name: menu
+          in: path
+          description: メニュー名
+          required: true
+          schema:
+            type: string
+        - name: column
+          in: path
+          description: REST用項目名
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: string
+                    example: 000-00000
+                  data:
+                    type: object
+                    items: {}
+                    example: {"id1": "name1", "id2": "name2", "id3": "name3"}
                   message:
                     type: string
         '401':

--- a/ita_root/ita_api_admin/swagger/swagger.yaml
+++ b/ita_root/ita_api_admin/swagger/swagger.yaml
@@ -37,6 +37,8 @@ tags:
   description: ログレベル設定
 - name: Backyard Execute Check
   description: バックヤード実行状態一括取得
+- name: Menu Info
+  description: メニュー情報の取得(Exastro Platform連携用) ※利用不可
 paths:
   /api/organizations/{organization_id}/ita/:
     post:
@@ -390,6 +392,65 @@ paths:
               schema:
                 $ref: '#/components/schemas/ERROR_TEMPLATE'
       x-openapi-router-controller: controllers.backyard_execute_check_controller
+  /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/info/notification/destination/{column}/:
+    get:
+      tags:
+      - Menu Info
+      description: 指定のメニューのカラムで利用している通知先を取得する
+      operationId: get_notification_destination
+      parameters:
+      - name: organization_id
+        in: path
+        description: OrganizationID
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: workspace_id
+        in: path
+        description: WorkspaceID
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: menu
+        in: path
+        description: メニュー名
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: column
+        in: path
+        description: REST用項目名
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inline_response_200_5'
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ERROR_TEMPLATE'
+      x-openapi-router-controller: controllers.menu_info_controller
 components:
   schemas:
     ERROR_TEMPLATE:
@@ -807,6 +868,27 @@ components:
                 last_update_timestamp: YYYY-MM-DD hh:mm:ss.xxxxxx
                 status_name: 未実行
                 id: (uuid)
+        message: message
+    inline_response_200_5:
+      type: object
+      properties:
+        result:
+          type: string
+          example: 000-00000
+        data:
+          type: object
+          example:
+            id1: name1
+            id2: name2
+            id3: name3
+        message:
+          type: string
+      example:
+        result: 000-00000
+        data:
+          id1: name1
+          id2: name2
+          id3: name3
         message: message
     inline_response_200_1_data_organization_id_initial_data_parameter:
       type: object


### PR DESCRIPTION
# 概要
「ita_api_admin」にPlatformから利用される想定のAPI定義を追加しました。

# 詳細
- Menu Infoのタグを追加
- GET /api/{organization_id}/workspaces/{workspace_id}/ita/menu/{menu}/info/notification/destination/{column}/ の定義を追加
- SwaggerEditorで生成した以下のファイルを追加
  - ita_root/ita_api_admin/controllers/menu_info_controller.py
  - ita_root/ita_api_admin/openapi.yaml
  - ita_root/ita_api_admin/swagger/swagger.yaml

# 動作確認内容
以下のコマンドでレスポンスが取得できることを確認
```
curl --request GET \
  --url http://ita-api-admin:8079/api/org1/workspaces/workspace-1/ita/menu/rule/info/notification/destination/before_notification_destination/ \
  --header 'accept: application/json' \
  --header 'roles: X3dvcmtzcGFjZS0xLWFkbWlu' \
  --header 'user-agent: vscode-restclient' \
  --header 'user-id: b4a68fa9-339a-4d4f-a872-46fd4c371971'
```

## 結果
```
[app_user@97bae4de7df2 workspace]$ curl --request GET \
>   --url http://ita-api-admin:8079/api/org1/workspaces/workspace-1/ita/menu/rule/info/notification/destination/before_notification_destination/ \
>   --header 'accept: application/json' \
>   --header 'roles: X3dvcmtzcGFjZS0xLWFkbWlu' \
>   --header 'user-agent: vscode-restclient' \
>   --header 'user-id: b4a68fa9-339a-4d4f-a872-46fd4c371971'
"do some magic!"
[app_user@97bae4de7df2 workspace]$ 
```