### PR TITLE
イベントフロー画面向けAPIの不備修正

### DIFF
--- a/ita_root/common_libs/common/mongoconnect/collection/labeled_event_collection.py
+++ b/ita_root/common_libs/common/mongoconnect/collection/labeled_event_collection.py
@@ -66,10 +66,10 @@ class LabeledEventCollection(CollectionBase):
         tmp_value = super()._create_search_value(collection_item_name, value)
 
         if collection_item_name == "labels._exastro_fetched_time":
-            return str(int(datetime.datetime.strptime(tmp_value, '%Y/%m/%d %H:%M:%S').timestamp()))
+            return int(datetime.datetime.strptime(tmp_value, '%Y/%m/%d %H:%M:%S').timestamp())
 
         if collection_item_name == "labels._exastro_end_time":
-            return str(int(datetime.datetime.strptime(tmp_value, '%Y/%m/%d %H:%M:%S').timestamp()))
+            return int(datetime.datetime.strptime(tmp_value, '%Y/%m/%d %H:%M:%S').timestamp())
 
         if collection_item_name == "labels._exastro_timeout":
             if value == "時間切れ":

--- a/ita_root/ita_api_organization/libs/oase.py
+++ b/ita_root/ita_api_organization/libs/oase.py
@@ -104,8 +104,8 @@ def collect_event_history(wsMongo: MONGOConnectWs, parameter: dict):
             fix_value = None
             # MongoDBのデータに合わせるため、時刻項目の場合UNIX時間に変換する。
             if key in TIME_PARAM:
-                dt = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S%z')
-                fix_value = str(int(dt.timestamp()))
+                dt = datetime.strptime(value, '%Y/%m/%d %H:%M:%S')
+                fix_value = int(dt.timestamp())
             # MongoDBのデータに合わせるため、Bool値の場合は一旦intに変換し、その後文字に変換する。
             elif key in BOOL_PARAM:
                 fix_value = str(int(value))
@@ -131,6 +131,14 @@ def collect_event_history(wsMongo: MONGOConnectWs, parameter: dict):
     result = []
     for item in event_history:
         item["_id"] = str(item["_id"])
+
+        if "exastro_events" in item:
+            item["exastro_events"] = [str(event) for event in item["exastro_events"]]
+
+        if "event" in item:
+            if "_id" in item["event"]:
+                item["event"]["_id"] = str(item["event"]["_id"])
+
         result.append(item)
 
     return result
@@ -209,7 +217,12 @@ def create_history_list(event_history: list, action_log: list):
 
         ts = int(event["labels"]["_exastro_fetched_time"])
         dt = datetime.fromtimestamp(ts)
-        append_data["datetime"] = dt.strftime("%Y-%m-%d %H:%M:%S")
+        append_data["datetime"] = dt.strftime("%Y/%m/%d %H:%M:%S")
+        event["labels"]["_exastro_fetched_time"] = dt.strftime("%Y/%m/%d %H:%M:%S")
+
+        ts = int(event["labels"]["_exastro_end_time"])
+        dt = datetime.fromtimestamp(ts)
+        event["labels"]["_exastro_end_time"] = dt.strftime("%Y/%m/%d %H:%M:%S")
 
         append_data["item"] = event
 


### PR DESCRIPTION
# 概要
- Request bodyで受け取る日付のフォーマットを以下の通り修正
  - 修正前
    - %Y-%m-%dT%H:%M:%S%z
  - 修正後
    - %Y/%m/%d %H:%M:%S
- 日時を検索する際、検索の値をstrからintに変更
  - 設定元がintで扱っていたため
- 以下の項目を返却する際「%Y/%m/%d %H:%M:%S」にフォーマットする処理を追加
  - labels._exastro_fetched_time
  - labels._exastro_end_time