### PR TITLE
イベントフロー及び通知処理の不備対応

### DIFF
--- a/ita_root/common_libs/notification/notification_base.py
+++ b/ita_root/common_libs/notification/notification_base.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 #
 
+import copy
 import json
 import os
 import re
@@ -61,9 +62,11 @@ class Notification(ABC):
         }
 
         for index, item in enumerate(event_list):
+            # _convert_messageでitemを直接書き換えると再実行時にエラーが発生する可能性があるため、複製したデータをベースに処理を行う。
+            tmp_item = copy.deepcopy(item)
             g.applogger.info(f"{index + 1}件目のイベントの処理開始")
 
-            message = cls._create_notise_message(item, template)
+            message = cls._create_notise_message(tmp_item, template)
             tmp_result = cls.__call_notification_api(message, notification_destination)
 
             result["success"] = result["success"] + tmp_result["success"]
@@ -168,7 +171,6 @@ class Notification(ABC):
 
         header_para = {
             "User-Id": user_id,
-            "Roles": json.dumps(g.ROLES),
             "Language": language
         }
 
@@ -229,7 +231,6 @@ class Notification(ABC):
         header_para = {
             "Content-Type": "application/json",
             "User-Id": user_id,
-            "Roles": json.dumps(g.ROLES),
             "Language": language
         }
 

--- a/ita_root/ita_api_organization/controllers/oase_controller.py
+++ b/ita_root/ita_api_organization/controllers/oase_controller.py
@@ -55,6 +55,7 @@ def get_oase_filter(organization_id, workspace_id, menu):  # noqa: E501
     result_data = oase.rest_filter(objdbca, menu, filter_parameter)
     return result_data,
 
+
 @api_filter
 def post_oase_filter(organization_id, workspace_id, menu, body=None):  # noqa: E501
     """post_oase_filter
@@ -93,6 +94,7 @@ def post_oase_filter(organization_id, workspace_id, menu, body=None):  # noqa: E
 
     result_data = oase.rest_filter(objdbca, menu, filter_parameter)
     return result_data,
+
 
 @api_filter
 def post_oase_history(organization_id, workspace_id, body=None):  # noqa: E501

--- a/ita_root/ita_api_organization/libs/oase.py
+++ b/ita_root/ita_api_organization/libs/oase.py
@@ -234,7 +234,12 @@ def create_history_list(event_history: list, action_log: list):
         append_data["type"] = "action"
 
         tr = action["TIME_REGISTER"]
-        append_data["datetime"] = tr.strftime("%Y-%m-%d %H:%M:%S")
+        tr_time = tr.strftime("%Y/%m/%d %H:%M:%S")
+        append_data["datetime"] = tr_time
+        action["TIME_REGISTER"] = tr_time
+
+        lut = action["LAST_UPDATE_TIMESTAMP"]
+        action["LAST_UPDATE_TIMESTAMP"] = lut.strftime("%Y/%m/%d %H:%M:%S.%f")
 
         append_data["item"] = action
 


### PR DESCRIPTION
# 概要
以下の修正を実施
- イベントフロー画面向けAPIにて返却する日付のフォーマットを統一（年月日の区切りを「/」に統一）
- 通知処理からPlatformのAPIを利用する際に設定するheaderからrolesを削除
- 通知処理にて同一のデータを複数回処理できるよう事前に複製する処理を追加