### PR TITLE
#1411 Restoreする際のテンプレートのバリデーション処理の不備を修正

### DIFF
--- a/ita_root/common_libs/notification/notification_base.py
+++ b/ita_root/common_libs/notification/notification_base.py
@@ -46,13 +46,20 @@ class Notification(ABC):
         g.applogger.info(f"通知に関する情報：{decision_information}")
 
         fetch_data = cls._fetch_table(objdbca, decision_information)
+        if fetch_data is None:
+            g.applogger.info("テーブルにデータが存在しないため処理を終了します。")
+            return {}
+
         template = cls._get_template(fetch_data, decision_information)
+        if template is None:
+            g.applogger.info("テンプレートが存在しないため処理を終了します。")
+            return {}
 
         # 負荷を考慮して通知先は1回のみ取得することとする
         notification_destination = cls._fetch_notification_destination(fetch_data, decision_information)
         if len(notification_destination) == 0:
             g.applogger.info("条件を満たす通知先が0件のため処理を終了します。")
-            return
+            return {}
 
         g.applogger.info(f"合計で通知する件数：{len(notification_destination) * len(event_list)}")
 
@@ -121,7 +128,7 @@ class Notification(ABC):
         """
         g.applogger.info(f"テンプレートのレンダリングに利用するオブジェクトのID:{item.get('_id')}")
 
-        # item = cls._convert_message(item)
+        item = cls._convert_message(item)
 
         jinja_template = Template(template)
         try:

--- a/ita_root/common_libs/notification/sub_classes/oase.py
+++ b/ita_root/common_libs/notification/sub_classes/oase.py
@@ -106,7 +106,11 @@ class OASE(Notification):
         g.applogger.info(f"_fetch_tableで実行するクエリの内容:\n{query}")
         g.applogger.info(f"_fetch_tableで実行するクエリの変数に渡す値:\n{values['condition_value']}")
 
-        return objdbca.sql_execute(query, values['condition_value']).pop()
+        query_result = objdbca.sql_execute(query, values['condition_value'])
+        if len(query_result) == 0:
+            return None
+
+        return query_result.pop()
 
     @classmethod
     def _get_template(cls, fetch_data, decision_information: dict):
@@ -119,6 +123,8 @@ class OASE(Notification):
         menu_id = values["menu_id"]
         rest_name = values["rest_name"]
         file_name = fetch_data["TEMPLATE_FILE"]
+        if file_name is None or file_name == '':
+            return None
 
         path = get_upload_file_path(workspace_id, menu_id, uuid, rest_name, file_name, "")
         g.applogger.info(f"取得するテンプレートのパス:\n{path}")
@@ -134,6 +140,9 @@ class OASE(Notification):
 
         if notification_type in [OASENotificationType.BEFORE_ACTION, OASENotificationType.AFTER_ACTION]:
             notification_destination_str = fetch_data.get("NOTIFICATION_DESTINATION")
+            if notification_destination_str is None or notification_destination_str == '':
+                return []
+
             notification_destination_dict = json.loads(notification_destination_str)
 
             g.applogger.info(f"ルールから取得した通知先：\n{notification_destination_dict['id']}")

--- a/ita_root/common_libs/validate/valid_110109.py
+++ b/ita_root/common_libs/validate/valid_110109.py
@@ -106,9 +106,9 @@ def external_valid_menu_before(objdbca, objtable, option):
         after_notification = option.get('current_parameter', {}).get('file', {}).get('after_notification', '')
 
     target = {}
-    if before_notification != '':
+    if before_notification != '' and before_notification is not None:
         target["before_notification"] = before_notification
-    if after_notification != '':
+    if after_notification != '' and after_notification is not None:
         target["after_notification"] = after_notification
 
     # テンプレートのアップロードが無い場合は以降のチェックが不要となるためこの時点で返却する
@@ -189,4 +189,3 @@ def __fetch_column_group_name(objdbca, col_group_id):
             "en": fetch_result[0]["COL_GROUP_NAME_EN"]
         }
     )
-


### PR DESCRIPTION
# 概要
- Restreの際の考慮が不足しており、テンプレートをアップロードしていない場合エラーが発生していたので修正を実施
- 通知処理全判の動作確認でガードの不足で落ちるパターンが見つかったため、落ちないよう処理の追加を実施